### PR TITLE
Unify implimentations of uproot and xAOD backends

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "Mlll",
+        "ROOTT",
         "Topo",
         "asyncio",
         "codecov",
@@ -17,8 +18,5 @@
         "unittests",
         "xaod"
     ],
-    "python.pythonPath": "c:\\Users\\gordo\\Documents\\Code\\func_adl_servicex\\.venv\\Scripts\\python.exe",
-    "python.testing.pytestArgs": [
-        "--no-cov"
-    ]
+    "python.pythonPath": "c:\\Users\\gordo\\Documents\\Code\\func_adl_servicex\\.venv\\Scripts\\python.exe"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,11 @@
 {
     "cSpell.words": [
+        "AZNLOCTEQ",
+        "DAOD",
         "Mlll",
+        "Powheg",
         "ROOTT",
+        "STDM",
         "Topo",
         "asyncio",
         "codecov",
@@ -18,5 +22,8 @@
         "unittests",
         "xaod"
     ],
-    "python.pythonPath": "c:\\Users\\gordo\\Documents\\Code\\func_adl_servicex\\.venv\\Scripts\\python.exe"
+    "python.pythonPath": "c:\\Users\\gordo\\Documents\\Code\\func_adl_servicex\\.venv\\Scripts\\python.exe",
+    "python.testing.pytestArgs": [
+        "--no-cov"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ See the further information for documentation above to understand how this works
 
 ```python
 from servicex import ServiceXDataset
-from func_adl_servicex import ServiceXDatasetSource
+from func_adl_servicex import ServiceXSourceUpROOT
 
 
 dataset_uproot = "user.kchoi:user.kchoi.ttHML_80fb_ttbar"
 uproot_transformer_image = "sslhep/servicex_func_adl_uproot_transformer:issue6"
 
 sx_dataset = ServiceXDataset(dataset_uproot, image=uproot_transformer_image)
-ds = ServiceXDatasetSource(sx_dataset, "nominal")
+ds = ServiceXSourceUpROOT(sx_dataset, "nominal")
 data = ds.Select("lambda e: {'lep_pt_1': e.lep_Pt_1, 'lep_pt_2': e.lep_Pt_2}") \
     .AsParquetFiles('junk.parquet') \
     .value()

--- a/README.md
+++ b/README.md
@@ -10,19 +10,9 @@ Send func_adl expressions to a ServiceX endpoint
 
 ## Introduction
 
-This package contains the single object `ServiceXDataset` which can be used as a root of a `func_adl` expression to query large LHC datasets from an active `ServiceX` instance located on the net.
+This package contains the single object `ServiceXSourceXAOD` and ``ServiceXSourceUpROOT` which can be used as a root of a `func_adl` expression to query large LHC datasets from an active `ServiceX` instance located on the net.
 
-For example, get get all the jet pt's above 30 GeV from an ATLAS xaod:
-
-```python
-example
-```
-
-And to fetch the same from a root tuple file:
-
-```python
-example
-```
+See below for simple examples.
 
 ### Further Information
 
@@ -35,10 +25,21 @@ To use `func_adl` on `servicex`, the only `func_adl` package you only need to in
 
 ## Using the xAOD backend
 
-See the further information for documentation above to understand how this works. Here is a quick sample that will run against an ATLAS xAOD backend in `servicex` to get out jet pt's
+See the further information for documentation above to understand how this works. Here is a quick sample that will run against an ATLAS `xAOD` backend in `servicex` to get out jet pt's for those jets with `pt > 30` GeV.
 
 ```python
-<get this done>
+from func_adl_servicex import ServiceXSourceXAOD
+
+dataset_xaod = "mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00"
+ds = ServiceXSourceXAOD(dataset_xaod)
+data = ds \
+    .SelectMany('lambda e: (e.Jets("AntiKt4EMTopoJets"))') \
+    .Where('lambda j: (j.pt()/1000)>30') \
+    .Select('lambda j: j.pt()') \
+    .AsAwkwardArray(["JetPt"]) \
+    .value()
+
+print(data['JetPt'])
 ```
 
 ## Using the uproot backend

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -1,7 +1,8 @@
 # Code to support running an ast at a remote func-adl server.
+from abc import ABC, abstractmethod
 import ast
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Union, cast
 
 import qastle
 from qastle import python_ast_to_text_ast
@@ -16,27 +17,48 @@ class FuncADLServerException (Exception):
         Exception.__init__(self, msg)
 
 
-class ServiceXDatasetSource (EventDataset):
+class ServiceXDatasetSourceBase (EventDataset, ABC):
     '''
-    A dataset for a func_adl query that is located on a ServiceX backend.
+    Base class for a ServiceX backend dataset.
     '''
-    def __init__(self, sx: Union[ServiceXDataset, str], treename: Optional[str] = None):
+    # How we map from func_adl to a servicex query
+    _ds_map = {
+        'ResultTTree': 'get_data_rootfiles_async',
+        'ResultParquet': 'get_data_parquet_async',
+        'ResultPandasDF': 'get_data_pandas_df_async',
+        'ResultAwkwardArray': 'get_data_awkward_async',
+    }
+
+    def __init__(self, sx: ServiceXDataset):
         '''
         Create a servicex dataset sequence from a servicex dataset
         '''
         super().__init__()
 
-        if isinstance(sx, str):
-            self._ds = ServiceXDataset(sx)
-        else:
-            self._ds = sx
+        self._ds = sx
 
-        # If we are doing a tree, modify the argument list to include a tree.
-        if treename is not None:
-            self.query_ast.args.append(ast.Str(s=treename))
+    @abstractmethod
+    def check_data_format_request(self, f_name: str):
+        '''Check to make sure the dataformat that is getting requested is ok. Throw an error
+        to give the user enough undersanding of why it isn't.
 
-        # TODO: #1 Code is custom tailored to deal with uproot vs xAOD here. Differences should be removed.
-        self._is_uproot = treename is not None
+        Args:
+            f_name (str): The function name of the final thing we are requesting.
+        '''
+
+    @abstractmethod
+    def generate_qastle(self, a: ast.Call) -> str:
+        '''Generate the qastle from the ast of the query.
+
+        1. The top level function is already marked as being "ok"
+        1. The top level function is included in this ast (you get the complete thing)
+
+        Args:
+            a (ast.AST): The complete AST of the request.
+
+        Returns:
+            str: Qastle that should be sent to servicex
+        '''
 
     async def execute_result_async(self, a: ast.AST) -> Any:
         r'''
@@ -50,51 +72,112 @@ class ServiceXDatasetSource (EventDataset):
         Returns:
             v                   Whatever the data that is requested (awkward arrays, etc.)
         '''
-        # Now, make sure the ast is formed in a way we cna deal with.
+        # Now, make sure the ast is formed in a way we can deal with.
         if not isinstance(a, ast.Call):
             raise FuncADLServerException(f'Unable to use ServiceX to fetch a {a}.')
         a_func = a.func
         if not isinstance(a_func, ast.Name):
-            raise FuncADLServerException(f'Unable to use ServiceX to fetch a call from {a_func}')
+            raise FuncADLServerException(f'Unable to use ServiceX to fetch a call from {ast.dump(a_func)}')
 
-        # Make the servicex call, asking for the appropriate return type. Depending on the return-type
-        # alter it so it can return something that ServiceX can understand.
+        # Check the call is legal for this datasource.
+        self.check_data_format_request(a_func.id)
 
-        if self._is_uproot:
-            # The uproot transformer only returns parquet files at the moment. So we had better look something like that, or something
-            # we can convert from.
+        # Get the qastle string for this query
+        q_str = self.generate_qastle(a)
+        logging.getLogger(__name__).debug(f'Qastle string sent to servicex: {q_str}')
 
-            if a_func.id == 'ResultParquet':
-                # For now, we have to strip off the ResultParquet and send the rest down to uproot.
-                source = a.args[0]
-                q_str = python_ast_to_text_ast(qastle.insert_linq_nodes(source))
-                logging.debug(f'Qastle string sent to uproot query: {q_str}')
-                return await self._ds.get_data_parquet_async(q_str)
-            elif a_func.id == 'ResultPandasDF':
-                raise NotImplementedError()
-            elif a_func.id == 'ResultAwkwardArray':
-                raise NotImplementedError()
-            else:
-                raise FuncADLServerException(f'Unable to use ServiceX to fetch a result in the form {a_func.id} - Only ResultParquet, ResultPandasDF and ResultAwkwardArray are supported')
+        # Next, run it, depending on the function
+        if a_func.id not in self._ds_map:
+            raise FuncADLServerException(f'Internal error - asked for {a_func.id} - but this dataset does not support it.')
+        name = self._ds_map[a_func.id]
+        attr = getattr(self._ds, name)
 
+        # Run it!
+        return await attr(q_str)
+
+
+class ServiceXSourceXAOD(ServiceXDatasetSourceBase):
+    def __init__(self, sx: Union[ServiceXDataset, str]):
+        '''
+        Create a servicex dataset sequence from a servicex dataset
+        '''
+        # Get the base created
+        if isinstance(sx, str):
+            ds = ServiceXDataset(sx, backend_type='xaod')
         else:
-            # If we are xAOD then we can come back with a pandas df, awkward array, or root files.
-            # TODO: #2 Add root files as a legal return type here.
-            if a_func.id == 'ResultPandasDF':
-                source = a.args[0]
-                cols = a.args[1]
-                top_level_ast = ast.Call(func=ast.Name('ResultTTree'), args=[source, cols, ast.Str('treeme'), ast.Str('file.root')])
-                q_str = python_ast_to_text_ast(top_level_ast)
-                logging.debug(f'Qastle string sent to xAOD query: {q_str}')
-                return await self._ds.get_data_pandas_df_async(q_str)
-            elif a_func.id == 'ResultAwkwardArray':
-                source = a.args[0]
-                cols = a.args[1]
-                top_level_ast = ast.Call(func=ast.Name('ResultTTree'), args=[source, cols, ast.Str('treeme'), ast.Str('file.root')])
-                q_str = python_ast_to_text_ast(top_level_ast)
-                logging.debug(f'Qastle string sent to xAOD query: {q_str}')
-                return await self._ds.get_data_awkward_async(q_str)
-            elif a_func.id == 'ResultTTree':
-                raise NotImplementedError()
-            else:
-                raise FuncADLServerException(f'Unable to use ServiceX to fetch a result in the form {a_func.id} - Only ResultTTree, ResultPandasDF and ResultAwkwardArray are supported')
+            ds = sx
+
+        super().__init__(ds)
+
+    def check_data_format_request(self, f_name: str):
+        '''Check to make sure things we are asking for here are ok. We really can't deal with Parquet files. Other than
+        that we are a go!
+
+        Args:
+            f_name (str): The function name we should check
+        '''
+        if f_name == 'ResultParquet':
+            raise FuncADLServerException('The AsParquetFiles datatype is not supported by the xAOD backend. Please use AsROOTTTrees, AsAwkward, or AsPandas')
+
+    def generate_qastle(self, a: ast.Call) -> str:
+        '''Genrate the `qastle` for a query to the xAOD backend
+
+        Args:
+            a (ast.AST): The query
+
+        Returns:
+            str: The `qastle`, ready to pass to the back end.
+        '''
+        # If this is a call for an awkward or pandas, then we need to convert it to a root tree array.
+        source = a
+        if cast(ast.Name, a.func).id != 'ResultTTree':
+            if len(a.args) != 2:
+                raise FuncADLServerException(f'Do not understand how to call {cast(ast.Name, a.func).id} - wrong number of arguments')
+            stream = a.args[0]
+            cols = a.args[1]
+            source = ast.Call(func=ast.Name('ResultTTree'), args=[stream, cols, ast.Str('treeme'), ast.Str('file.root')])
+
+        return python_ast_to_text_ast(qastle.insert_linq_nodes(source))
+
+
+class ServiceXSourceUpROOT(ServiceXDatasetSourceBase):
+    def __init__(self, sx: Union[ServiceXDataset, str], treename: str):
+        '''
+        Create a servicex dataset sequence from a servicex dataset
+        '''
+        # Get the base created.
+        if isinstance(sx, str):
+            ds = ServiceXDataset(sx, backend_type='uproot')
+        else:
+            ds = sx
+
+        super().__init__(ds)
+
+        # Modify the argument list in EventDataSset to include the tree name.
+        self.query_ast.args.append(ast.Str(s=treename))  # type: ignore
+
+    def check_data_format_request(self, f_name: str):
+        '''Check to make sure things we are asking for here are ok. We really can't deal with Parquet files. Other than
+        that we are a go!
+
+        Args:
+            f_name (str): The function name we should check
+        '''
+        if f_name == 'ResultTTree':
+            raise FuncADLServerException('The AsROOTTTrees datatype is not supported by the xAOD backend. Please use AsParquetFiles, AsAwkward, or AsPandas')
+
+    def generate_qastle(self, a: ast.Call) -> str:
+        '''Genrate the `qastle` for a query to the uproot backend
+
+        Args:
+            a (ast.AST): The query
+
+        Returns:
+            str: The `qastle`, ready to pass to the back end.
+        '''
+        # We need to pull the top off it - the request for the particular data type (parquet, pandas, etc.)
+        # should not get passed to the transformer.
+        source = a.args[0]
+
+        # And that is all we need!
+        return python_ast_to_text_ast(qastle.insert_linq_nodes(source))

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -137,7 +137,7 @@ class ServiceXSourceXAOD(ServiceXDatasetSourceBase):
             cols = a.args[1]
             source = ast.Call(func=ast.Name('ResultTTree'), args=[stream, cols, ast.Str('treeme'), ast.Str('file.root')])
 
-        return python_ast_to_text_ast(qastle.insert_linq_nodes(source))
+        return python_ast_to_text_ast(source)
 
 
 class ServiceXSourceUpROOT(ServiceXDatasetSourceBase):

--- a/func_adl_servicex/__init__.py
+++ b/func_adl_servicex/__init__.py
@@ -1,3 +1,3 @@
 # Main two things from this package
 # flake8: noqa
-from .ServiceX import ServiceXDatasetSource, FuncADLServerException  # NOQA
+from .ServiceX import ServiceXSourceUpROOT, ServiceXSourceXAOD, FuncADLServerException  # NOQA

--- a/scripts/run_uproot.py
+++ b/scripts/run_uproot.py
@@ -11,7 +11,7 @@ def simple_call():
     sx_dataset = ServiceXDataset(dataset_uproot, image=uproot_transformer_image)
     ds = ServiceXSourceUpROOT(sx_dataset, "nominal")
     data = ds.Select("lambda e: {'lep_pt_1': e.lep_Pt_1, 'lep_pt_2': e.lep_Pt_2}") \
-        .AsParquetFiles('junk.parquet') \
+        .AsAwkwardArray() \
         .value()
 
     print(data)

--- a/scripts/run_uproot.py
+++ b/scripts/run_uproot.py
@@ -1,7 +1,7 @@
 # Show we can run up-root
 
 from servicex import ServiceXDataset
-from func_adl_servicex import ServiceXDatasetSource
+from func_adl_servicex import ServiceXSourceUpROOT
 
 
 def simple_call():
@@ -9,7 +9,7 @@ def simple_call():
     uproot_transformer_image = "sslhep/servicex_func_adl_uproot_transformer:issue6"
 
     sx_dataset = ServiceXDataset(dataset_uproot, image=uproot_transformer_image)
-    ds = ServiceXDatasetSource(sx_dataset, "nominal")
+    ds = ServiceXSourceUpROOT(sx_dataset, "nominal")
     data = ds.Select("lambda e: {'lep_pt_1': e.lep_Pt_1, 'lep_pt_2': e.lep_Pt_2}") \
         .AsParquetFiles('junk.parquet') \
         .value()

--- a/scripts/run_uproot.py
+++ b/scripts/run_uproot.py
@@ -11,7 +11,7 @@ def simple_call():
     sx_dataset = ServiceXDataset(dataset_uproot, image=uproot_transformer_image)
     ds = ServiceXSourceUpROOT(sx_dataset, "nominal")
     data = ds.Select("lambda e: {'lep_pt_1': e.lep_Pt_1, 'lep_pt_2': e.lep_Pt_2}") \
-        .AsAwkwardArray() \
+        .AsParquetFiles('junk.parquet') \
         .value()
 
     print(data)

--- a/scripts/run_xaod.py
+++ b/scripts/run_xaod.py
@@ -4,7 +4,7 @@ from func_adl_servicex import ServiceXSourceXAOD
 
 
 def simple_call():
-    dataset_xaod = "user.kchoi:user.kchoi.ttHML_80fb_ttbar"
+    dataset_xaod = "mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00"
     ds = ServiceXSourceXAOD(dataset_xaod)
     data = ds \
         .SelectMany('lambda e: (e.Jets("AntiKt4EMTopoJets"))') \
@@ -17,4 +17,9 @@ def simple_call():
 
 
 if __name__ == "__main__":
+    # import logging
+    # ch = logging.StreamHandler()
+    # ch.setLevel(logging.DEBUG)
+    # logging.getLogger('servicex').setLevel(logging.DEBUG)
+    # logging.getLogger('servicex').addHandler(ch)
     simple_call()

--- a/scripts/run_xaod.py
+++ b/scripts/run_xaod.py
@@ -1,0 +1,20 @@
+# Show we can run up-root
+
+from func_adl_servicex import ServiceXSourceXAOD
+
+
+def simple_call():
+    dataset_xaod = "user.kchoi:user.kchoi.ttHML_80fb_ttbar"
+    ds = ServiceXSourceXAOD(dataset_xaod)
+    data = ds \
+        .SelectMany('lambda e: (e.Jets("AntiKt4EMTopoJets"))') \
+        .Where('lambda j: (j.pt()/1000)>30') \
+        .Select('lambda j: (j.pt())') \
+        .AsROOTTTree('file.root', 'tree-me', "JetPt") \
+        .value()
+
+    print(data)
+
+
+if __name__ == "__main__":
+    simple_call()

--- a/scripts/run_xaod.py
+++ b/scripts/run_xaod.py
@@ -12,7 +12,6 @@ def simple_call():
         .Select('lambda j: j.pt()') \
         .AsAwkwardArray(["JetPt"]) \
         .value()
-    # .AsROOTTTree('file.root', 'tree-me', "JetPt") \
 
     print(data['JetPt'])
 

--- a/scripts/run_xaod.py
+++ b/scripts/run_xaod.py
@@ -9,11 +9,12 @@ def simple_call():
     data = ds \
         .SelectMany('lambda e: (e.Jets("AntiKt4EMTopoJets"))') \
         .Where('lambda j: (j.pt()/1000)>30') \
-        .Select('lambda j: (j.pt())') \
-        .AsROOTTTree('file.root', 'tree-me', "JetPt") \
+        .Select('lambda j: j.pt()') \
+        .AsAwkwardArray(["JetPt"]) \
         .value()
+    # .AsROOTTTree('file.root', 'tree-me', "JetPt") \
 
-    print(data)
+    print(data['JetPt'])
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,9 @@ with open("README.md", "r") as fh:
 
 version = os.getenv('func_adl_servicex_version')
 if version is None:
-    raise Exception('func_adl_servicex_version env var is not set')
-version = version.split('/')[-1]
+    version = '0.1a1'
+else:
+    version = version.split('/')[-1]
 
 setup(name="func_adl_servicex",
       version=version,
@@ -29,7 +30,7 @@ setup(name="func_adl_servicex",
       install_requires=[
           "func_adl>=2.0a1",
           "qastle==0.8",
-          "servicex>=2.0"
+          "servicex>=3.0b1"
       ],
       extras_require={
           'test': [

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name="func_adl_servicex",
       install_requires=[
           "func_adl>=2.0a1",
           "qastle==0.8",
-          "servicex>=3.0b1"
+          "servicex>=2.1b1, <3.0a1"
       ],
       extras_require={
           'test': [

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -113,7 +113,7 @@ def test_sx_xaod_root(async_mock):
 
     q.value()
 
-    sx.get_data_rootfiles_async.assert_called_with("(call ResultTTree (Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'my_tree' 'junk.root')")
+    sx.get_data_rootfiles_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'my_tree' 'junk.root')")
 
 
 def test_sx_xaod_awkward(async_mock):
@@ -124,7 +124,7 @@ def test_sx_xaod_awkward(async_mock):
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(call ResultTTree (Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'file.root')")
+    sx.get_data_awkward_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'file.root')")
 
 
 def test_sx_xaod_pandas(async_mock):
@@ -135,7 +135,7 @@ def test_sx_xaod_pandas(async_mock):
 
     q.value()
 
-    sx.get_data_pandas_df_async.assert_called_with("(call ResultTTree (Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'file.root')")
+    sx.get_data_pandas_df_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'file.root')")
 
 
 def test_bad_call(async_mock):

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -1,21 +1,22 @@
 # Tests to make sure we get at the functionality in the remote executor.
 import ast
-from pathlib import Path
 
-import pandas as pd
 import pytest
+from func_adl import ObjectStream
 from servicex import ServiceXDataset
 
-from func_adl import ObjectStream
-from func_adl_servicex import ServiceXDatasetSource
-from func_adl_servicex.ServiceX import FuncADLServerException
+from func_adl_servicex.ServiceX import (FuncADLServerException,
+                                        ServiceXDatasetSourceBase,
+                                        ServiceXSourceUpROOT,
+                                        ServiceXSourceXAOD)
 
 
 async def do_exe(a):
     return a
 
 
-def get_async_mock(mocker):
+@pytest.fixture
+def async_mock(mocker):
     import sys
     if sys.version_info[1] <= 7:
         import asyncmock
@@ -24,35 +25,123 @@ def get_async_mock(mocker):
         return mocker.MagicMock
 
 
-@pytest.fixture()
-def simple_Servicex_fe_watcher(mocker):
-    'Mock out the servicex guy'
-    m_servicex = get_async_mock(mocker)(spec=ServiceXDataset)
-    m_servicex.get_data_pandas_df_async.return_value = pd.DataFrame()
-    m_servicex.get_data_parquet_async.return_value = [Path('junk1.parquet')]
-    p_servicex = mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset',
-                              return_value=m_servicex)
-    return m_servicex, p_servicex
+def test_sx_abs(mocker):
+    'Make sure that we cannot build the abstract base class'
+    sx = mocker.MagicMock(spec=ServiceXDataset)
+    with pytest.raises(Exception):
+        ServiceXDatasetSourceBase(sx)  # type: ignore
 
 
-def test_sx_dataset(mocker):
-    dummy_ds = mocker.MagicMock(spec=ServiceXDataset)
-    a = ServiceXDatasetSource(dummy_ds) \
-        .value(executor=do_exe)
-
-    assert isinstance(a, ast.Call)
-
-
-def test_find_EventDataSet_good():
-    a = ServiceXDatasetSource("file://junk.root") \
-        .value(executor=do_exe)
-
-    assert isinstance(a, ast.Call)
+def test_sx_uproot(async_mock):
+    'Make sure we turn the execution into a call with an uproot'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    a = ds.value(executor=do_exe)
+    assert ast.dump(a) == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Constant(value='ServiceXSourceUpROOT'), Str(s='my_tree')], keywords=[])"
 
 
-def test_bad_call():
+def test_sx_uproot_root(async_mock):
+    'Test a request for parquet files from an xAOD guy bombs'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    q = ds.Select("lambda e: e.MET").AsROOTTTree('junk.parquet', 'another_tree', ['met'])
+
+    with pytest.raises(FuncADLServerException) as e:
+        q.value()
+
+    assert 'not supported' in str(e.value)
+
+
+def test_sx_uproot_parquet(async_mock):
+    'Test a request for parquet files from an xAOD guy bombs'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
+
+    q.value()
+
+    sx.get_data_parquet_async.assert_called_with("(Select (call EventDataset 'ServiceXSourceUpROOT' 'my_tree') (lambda (list e) (attr e 'MET')))")
+
+
+def test_sx_uproot_awkward(async_mock):
+    'Test a request for awkward data from an xAOD guy bombs'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    q = ds.Select("lambda e: e.MET").AsAwkwardArray(['met'])
+
+    q.value()
+
+    sx.get_data_awkward_async.assert_called_with("(Select (call EventDataset 'ServiceXSourceUpROOT' 'my_tree') (lambda (list e) (attr e 'MET')))")
+
+
+def test_sx_uproot_pandas(async_mock):
+    'Test a request for awkward data from an xAOD guy bombs'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    q = ds.Select("lambda e: e.MET").AsPandasDF(['met'])
+
+    q.value()
+
+    sx.get_data_pandas_df_async.assert_called_with("(Select (call EventDataset 'ServiceXSourceUpROOT' 'my_tree') (lambda (list e) (attr e 'MET')))")
+
+
+def test_sx_xaod(async_mock):
+    'Make sure we turn the execution into a call with an uproot'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+    a = ds.value(executor=do_exe)
+    assert ast.dump(a) == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Constant(value='ServiceXSourceXAOD')], keywords=[])"
+
+
+def test_sx_xaod_parquet(async_mock):
+    'Test a request for parquet files from an xAOD guy bombs'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+    q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
+
+    with pytest.raises(FuncADLServerException) as e:
+        q.value()
+
+    assert 'not supported' in str(e.value)
+
+
+def test_sx_xaod_root(async_mock):
+    'Test a request for root files from an xAOD guy'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+    q = ds.Select("lambda e: e.MET").AsROOTTTree('junk.root', 'my_tree', ['met'])
+
+    q.value()
+
+    sx.get_data_rootfiles_async.assert_called_with("(call ResultTTree (Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'my_tree' 'junk.root')")
+
+
+def test_sx_xaod_awkward(async_mock):
+    'Test a request for awkward arrays from an xAOD backend'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+    q = ds.Select("lambda e: e.MET").AsAwkwardArray(['met'])
+
+    q.value()
+
+    sx.get_data_awkward_async.assert_called_with("(call ResultTTree (Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'file.root')")
+
+
+def test_sx_xaod_pandas(async_mock):
+    'Test a request for awkward arrays from an xAOD backend'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+    q = ds.Select("lambda e: e.MET").AsPandasDF(['met'])
+
+    q.value()
+
+    sx.get_data_pandas_df_async.assert_called_with("(call ResultTTree (Select (call EventDataset 'ServiceXSourceXAOD') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'file.root')")
+
+
+def test_bad_call(async_mock):
     'Normally expect ast.Call - what if not?'
-    ds = ServiceXDatasetSource("file://junk.root")
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
     next = ast.BinOp(left=ds.query_ast, op=ast.Add(), right=ast.Num(n=10))
 
     with pytest.raises(FuncADLServerException) as e:
@@ -62,9 +151,10 @@ def test_bad_call():
     assert "Unable" in str(e.value)
 
 
-def test_bad_wrong_call_type():
+def test_bad_wrong_call_type(async_mock):
     'A call needs to be vs a Name node, not something else?'
-    ds = ServiceXDatasetSource("file://junk.root")
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
     next = ast.Call(func=ast.Attribute(value=ds.query_ast, attr='dude'))
 
     with pytest.raises(FuncADLServerException) as e:
@@ -74,10 +164,25 @@ def test_bad_wrong_call_type():
     assert "fetch a call from" in str(e.value)
 
 
-def test_bad_wrong_call_name():
+def test_ctor_xaod(mocker):
+    call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
+    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
+    ServiceXSourceXAOD('did_1221')
+    call.assert_called_with('did_1221', backend_type='xaod')
+
+
+def test_ctor_uproot(mocker):
+    call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
+    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
+    ServiceXSourceUpROOT('did_1221', 'a_tree')
+    call.assert_called_with('did_1221', backend_type='uproot')
+
+
+def test_bad_wrong_call_name_right_args(async_mock):
     'A call needs to be vs a Name node, not something else?'
-    ds = ServiceXDatasetSource("file://junk.root")
-    next = ast.Call(func=ast.Name(id='ResultBogus'), args=[ds.query_ast])
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+    next = ast.Call(func=ast.Name(id='ResultBogus'), args=[ds.query_ast, ast.Name('cos')])
 
     with pytest.raises(FuncADLServerException) as e:
         ObjectStream(next) \
@@ -86,90 +191,14 @@ def test_bad_wrong_call_name():
     assert "ResultBogus" in str(e.value)
 
 
-def test_as_qastle_xaod():
-    a = ServiceXDatasetSource("junk.root")
-    from qastle import python_ast_to_text_ast
-    q = python_ast_to_text_ast(a.query_ast)
-    assert q == "(call EventDataset 'ServiceXDatasetSource')"
+def test_bad_wrong_call_name(async_mock):
+    'A call needs to be vs a Name node, not something else?'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+    next = ast.Call(func=ast.Name(id='ResultBogus'), args=[ds.query_ast])
 
+    with pytest.raises(FuncADLServerException) as e:
+        ObjectStream(next) \
+            .value()
 
-def test_as_qastle_uproot():
-    a = ServiceXDatasetSource("junk.root", 'MainTree')
-    from qastle import python_ast_to_text_ast
-    q = python_ast_to_text_ast(a.query_ast)
-    assert q == "(call EventDataset 'ServiceXDatasetSource' 'MainTree')"
-
-
-@pytest.mark.asyncio
-async def test_uproot_parquet_query(simple_Servicex_fe_watcher):
-    'Simple parquet based query going to xAOD'
-    f_ds = ServiceXDatasetSource(r'bogus_ds', 'tree-to-scan')
-    r = await f_ds \
-        .SelectMany("lambda e: e.jet_pt") \
-        .Select("lambda j: j / 1000.0") \
-        .AsParquetFiles('junk.parquet', ['JetPt']) \
-        .value_async()
-    assert r is not None
-    assert isinstance(r, list)
-    assert len(r) == 1
-
-    caller = simple_Servicex_fe_watcher[0].get_data_parquet_async
-    caller.assert_called_once()
-    args = caller.call_args[0]
-    assert len(args) == 1
-    assert args[0].find('SelectMany') >= 0
-    assert 'ResultParquet' not in args[0]
-
-
-@pytest.mark.asyncio
-async def test_xaod_pandas_query(simple_Servicex_fe_watcher):
-    'Simple pandas based query'
-    f_ds = ServiceXDatasetSource(r'bogus_ds')
-    r = await f_ds \
-        .SelectMany('lambda e: e.Jets("AntiKt4EMTopoJets")') \
-        .Select('lambda j: j.pt()/1000.0') \
-        .AsPandasDF('JetPt') \
-        .value_async()
-    assert r is not None
-    assert isinstance(r, pd.DataFrame)
-    assert len(r) == 0
-
-    caller = simple_Servicex_fe_watcher[0].get_data_pandas_df_async
-    caller.assert_called_once()
-    args = caller.call_args[0]
-    assert len(args) == 1
-    assert args[0].find('SelectMany') >= 0
-    assert args[0].startswith('(call ResultTTree')
-
-
-@pytest.mark.asyncio
-async def test_xaod_awkward_query(simple_Servicex_fe_watcher):
-    'Simple pandas based query'
-    f_ds = ServiceXDatasetSource(r'bogus_ds')
-    await f_ds \
-        .SelectMany('lambda e: e.Jets("AntiKt4EMTopoJets")') \
-        .Select('lambda j: j.pt()/1000.0') \
-        .AsAwkwardArray('JetPt') \
-        .value_async()
-
-    caller = simple_Servicex_fe_watcher[0].get_data_awkward_async
-    caller.assert_called_once()
-    args = caller.call_args[0]
-    assert len(args) == 1
-    assert args[0].find('SelectMany') >= 0
-    assert args[0].startswith('(call ResultTTree')
-
-
-@pytest.mark.asyncio
-async def test_xaod_scoped_dataset_name(simple_Servicex_fe_watcher):
-    'Simple pandas based query'
-    f_ds = ServiceXDatasetSource(r'user.fork:bogus_ds')
-    _ = await f_ds \
-        .SelectMany('lambda e: e.Jets("AntiKt4EMTopoJets")') \
-        .Select('lambda j: j.pt()/1000.0') \
-        .AsPandasDF('JetPt') \
-        .value_async()
-
-    simple_Servicex_fe_watcher[1].assert_called_once()
-    assert simple_Servicex_fe_watcher[1].call_args[0][0] \
-        == 'user.fork:bogus_ds'
+    assert "ResultBogus" in str(e.value)


### PR DESCRIPTION
This work brings (hopefully) this package to the 1.0 release point:

- Creates an xAOD and uproot data set source, otherwise does its best to make the two look the same when you use them.
- Allows for fetching of awkward arrays or pandas df from either one
- allows for fetching of root files from the xaod, and parquet from the uproot
- Some simple integrated tests that can be run by hand
- Gets code test coverage up to 100%