### PR TITLE
Support Python 3.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7]
+        python-version: [3.6, 3.7]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -135,7 +135,7 @@ class ServiceXSourceXAOD(ServiceXDatasetSourceBase):
                 raise FuncADLServerException(f'Do not understand how to call {cast(ast.Name, a.func).id} - wrong number of arguments')
             stream = a.args[0]
             cols = a.args[1]
-            source = ast.Call(func=ast.Name('ResultTTree'), args=[stream, cols, ast.Str('treeme'), ast.Str('file.root')])
+            source = ast.Call(func=ast.Name(id='ResultTTree', ctx=ast.Load()), args=[stream, cols, ast.Str('treeme'), ast.Str('file.root')])
 
         return python_ast_to_text_ast(source)
 

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -182,7 +182,9 @@ def test_bad_wrong_call_name_right_args(async_mock):
     'A call needs to be vs a Name node, not something else?'
     sx = async_mock(spec=ServiceXDataset)
     ds = ServiceXSourceXAOD(sx)
-    next = ast.Call(func=ast.Name(id='ResultBogus'), args=[ds.query_ast, ast.Name('cos')])
+    next = ast.Call(
+        func=ast.Name(id='ResultBogus', ctx=ast.Load()),
+        args=[ds.query_ast, ast.Name(id='cos', ctx=ast.Load())])
 
     with pytest.raises(FuncADLServerException) as e:
         ObjectStream(next) \


### PR DESCRIPTION
# Problem
The signature to the ast.Name constructor changed between 3.6 and 3.7 - an argument was made optional. The code fails on 3.6

# Approach
Add back the optional argument and add 3.6 tests