### PR TITLE
Update qastle 0.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,11 @@ jobs:
       if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       run: |
         flake8 --exclude=tests/* --ignore=E501
+    - name: Check for vulnerable libraries
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      run: |
+        pip install safety
+        pip freeze | safety check
     - name: Test with pytest
       run: |
         python -m pytest

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(name="func_adl_servicex",
       test_suite="tests",
       install_requires=[
           "func_adl>=2.0, <3.0",
-          "qastle==0.8",
-          "servicex>=2.1, <3.0a1"
+          "qastle>=0.10, <1.0",
+          "servicex>=2.1.2, <3.0a1"
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
# Problem
The qastle library has been upgraded to 0.10, this library was pinned at an earlier version

# Approach
Updated the setup.py to float qastle library until we reach 1.0 for that library

Added a safety check to the CI job