### PR TITLE
Rewrite to be used with cms run1 aod

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,7 @@
         "unittests",
         "xaod"
     ],
-    "python.pythonPath": "c:\\Users\\gordo\\Documents\\Code\\func_adl_servicex\\.venv\\Scripts\\python.exe",
+    "python.pythonPath": ".venv\\Scripts\\python.exe",
     "python.testing.pytestArgs": [
         "--no-cov"
     ]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ data = ds \
 print(data['JetPt'])
 ```
 
+## Using the CMS Run 1 AOD backend
+
+See the further information for documentation above to understand how this works. Here is a quick sample that will run against an CMS Run 1 `AOD` backend in `servicex`. It turns against a 6 TB CMS Open Data dataset, selecting global muons with a pT greater than 30 GeV.
+
+```python
+from func_adl_servicex import ServiceXSourceCMSRun1AOD
+
+dataset_xaod = "cernopendata://16"
+ds = ServiceXSourceCMSRun1AOD(dataset_xaod)
+data = ds \
+data = ServiceXSourceCMSRun1AOD("cernopendata://16") \
+    .SelectMany(lambda e: e.TrackMuons("globalMuons")) \
+    .Where(lambda m: m.pt() > 30) \
+    .Select(lambda m: m.pt()) \
+    .AsAwkwardArray(['mu_pt']) \
+    .value()
+
+print(data['mu_pt'])
+```
+
 ## Using the uproot backend
 
 See the further information for documentation above to understand how this works. Here is a quick sample that will run against a ROOT file (TTree) in the `uproot` backend in `servicex` to get out jet pt's. Note that the image name tag is likely wrong here. See XXX to get the current one.

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -96,10 +96,13 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
         return await attr(q_str)
 
 
-class ServiceXSourceXAOD(ServiceXDatasetSourceBase):
-    def __init__(self, sx: Union[ServiceXDataset, str]):
-        '''
-        Create a servicex dataset sequence from a servicex dataset
+class ServiceXSourceCPPBase(ServiceXDatasetSourceBase):
+    def __init__(self, sx: Union[ServiceXDataset, str], backend_type: str):
+        '''Create a C++ backend data set source
+
+        Args:
+            sx (Union[ServiceXDataset, str]): The ServiceX dataset or dataset source.
+            backend_type (str): The backend type, `xaod`, for example, for the ATLAS R21 xaod
         '''
         # Get the base created
         if isinstance(sx, str):
@@ -138,6 +141,22 @@ class ServiceXSourceXAOD(ServiceXDatasetSourceBase):
             source = ast.Call(func=ast.Name(id='ResultTTree', ctx=ast.Load()), args=[stream, cols, ast.Str('treeme'), ast.Str('file.root')])
 
         return python_ast_to_text_ast(source)
+
+
+class ServiceXSourceXAOD(ServiceXSourceCPPBase):
+    def __init__(self, sx: Union[ServiceXDataset, str]):
+        '''
+        Create a servicex dataset sequence from a servicex dataset
+        '''
+        super().__init__(sx, 'xaod')
+
+
+class ServiceXSourceCMSRun1AOD(ServiceXSourceCPPBase):
+    def __init__(self, sx: Union[ServiceXDataset, str]):
+        '''
+        Create a servicex dataset sequence from a servicex dataset
+        '''
+        super().__init__(sx, 'cms_run1_aod')
 
 
 class ServiceXSourceUpROOT(ServiceXDatasetSourceBase):

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -106,7 +106,7 @@ class ServiceXSourceCPPBase(ServiceXDatasetSourceBase):
         '''
         # Get the base created
         if isinstance(sx, str):
-            ds = ServiceXDataset(sx, backend_type='xaod')
+            ds = ServiceXDataset(sx, backend_type=backend_type)
         else:
             ds = sx
 

--- a/func_adl_servicex/__init__.py
+++ b/func_adl_servicex/__init__.py
@@ -1,3 +1,3 @@
 # Main two things from this package
 # flake8: noqa
-from .ServiceX import ServiceXSourceUpROOT, ServiceXSourceXAOD, FuncADLServerException  # NOQA
+from .ServiceX import ServiceXSourceUpROOT, ServiceXSourceXAOD, ServiceXSourceCMSRun1AOD, FuncADLServerException  # NOQA

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name="func_adl_servicex",
       license="TBD",
       test_suite="tests",
       install_requires=[
-          "func_adl>=2.0, <3.0",
+          "func_adl>=2.2, <3.0",
           "qastle>=0.10, <1.0",
           "servicex>=2.1.2, <3.0a1"
       ],

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -6,7 +6,7 @@ from func_adl import ObjectStream
 from servicex import ServiceXDataset
 
 from func_adl_servicex.ServiceX import (FuncADLServerException,
-                                        ServiceXDatasetSourceBase,
+                                        ServiceXDatasetSourceBase, ServiceXSourceCMSRun1AOD,
                                         ServiceXSourceUpROOT,
                                         ServiceXSourceXAOD)
 
@@ -171,6 +171,13 @@ def test_ctor_xaod(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
     mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
     ServiceXSourceXAOD('did_1221')
+    call.assert_called_with('did_1221', backend_type='xaod')
+
+
+def test_ctor_cms(mocker):
+    call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
+    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
+    ServiceXSourceCMSRun1AOD('did_1221')
     call.assert_called_with('did_1221', backend_type='xaod')
 
 

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -178,7 +178,7 @@ def test_ctor_cms(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
     mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
     ServiceXSourceCMSRun1AOD('did_1221')
-    call.assert_called_with('did_1221', backend_type='xaod')
+    call.assert_called_with('did_1221', backend_type='cms_run1_aod')
 
 
 def test_ctor_uproot(mocker):


### PR DESCRIPTION
* Add a new object, `ServiceXSourceCMSRun1AOD` which defaults source for CMS Run 1 AOD backends.
   * It is identical to the xAOD backend, but uses a different default backend name.

This will fix #19
