### PR TITLE
Return qastle instead of running directly

### DIFF
--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -37,6 +37,15 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
         super().__init__()
 
         self._ds = sx
+        self._return_qastle = False
+
+    @property
+    def return_qastle(self):
+        return self._return_qastle
+
+    @return_qastle.setter
+    def return_qastle(self, value: bool):
+        self._return_qastle = value
 
     @abstractmethod
     def check_data_format_request(self, f_name: str):
@@ -90,9 +99,15 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
         q_str = self.generate_qastle(a)
         logging.getLogger(__name__).debug(f'Qastle string sent to servicex: {q_str}')
 
-        # Next, run it, depending on the function
+        # Find the function we need to run against.
         if a_func.id not in self._ds_map:
             raise FuncADLServerException(f'Internal error - asked for {a_func.id} - but this dataset does not support it.')
+
+        # If only qastle is wanted, return here.
+        if self.return_qastle:
+            return q_str
+
+        # Next, run it, depending on the function
         name = self._ds_map[a_func.id]
         attr = getattr(self._ds, name)
 

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -66,6 +66,19 @@ def test_sx_uproot_parquet(async_mock):
     sx.get_data_parquet_async.assert_called_with("(Select (call EventDataset 'my_tree') (lambda (list e) (attr e 'MET')))")
 
 
+def test_sx_uproot_parquet_qastle(async_mock):
+    'Test a request for parquet files from an xAOD guy bombs'
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    ds.return_qastle = True
+    q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
+
+    result = q.value()
+
+    assert result == "(Select (call EventDataset 'my_tree') (lambda (list e) (attr e 'MET')))"
+    sx.get_data_parquet_async.assert_not_called()
+
+
 def test_sx_uproot_awkward(async_mock):
     'Test a request for awkward data from an xAOD guy bombs'
     sx = async_mock(spec=ServiceXDataset)


### PR DESCRIPTION
This allows one to use the infrastructure to generate qastle directly, and then one can use that to call directly ServiceX datasets