### PR TITLE
Streamline and Automate Access

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   flake8:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -41,7 +40,8 @@ jobs:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.platform }}
-
+    needs: flake8
+ 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,34 @@ on:
   - cron:  '1 0 * * *'
 
 jobs:
-  test:
+  flake8:
 
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      env:
+        func_adl_servicex_version: 1.0a1
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install --no-cache-dir -e .[test]
+        pip list
+    - name: Lint with Flake8
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      run: |
+        flake8 --exclude=tests/* --ignore=E501
+    - name: Check for vulnerable libraries
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      run: |
+        pip install safety
+        pip freeze | safety check
+
+  test:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
@@ -27,18 +53,8 @@ jobs:
         func_adl_servicex_version: 1.0a1
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install git+https://github.com/iris-hep/ast-language.git@e6470deb68529e1885a4bc46f781e2fe43a6f4c8
         pip install --no-cache-dir -e .[test]
         pip list
-    - name: Lint with Flake8
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      run: |
-        flake8 --exclude=tests/* --ignore=E501
-    - name: Check for vulnerable libraries
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      run: |
-        pip install safety
-        pip freeze | safety check
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # Run daily at 0:01 UTC
   schedule:
-  - cron:  '1 0 * * *'
+  - cron:  '1 0 * * 0'
 
 jobs:
   flake8:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Code Coverage",
+            "type": "shell",
+            "command": ". .venv/scripts/activate.ps1 ; coverage-3.9.exe run -m pytest",
+            "problemMatcher": []
+        },
+    ]
+}

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -111,8 +111,6 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
             assert default_format is not None, 'Unsupported ServiceX returned format'
             method_to_call = self._format_map[default_format]
 
-            if len(a.args) != 2:
-                raise FuncADLServerException(f'Do not understand how to call {cast(ast.Name, a.func).id} - wrong number of arguments')
             stream = a.args[0]
             col_names = a.args[1]
             if method_to_call == 'get_data_rootfiles_async':
@@ -123,7 +121,8 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
                 source = ast.Call(
                     func=ast.Name(id='ResultParquet', ctx=ast.Load()),
                     args=[stream, col_names, ast.Str('junk.parquet')])
-            else:
+            else:  # pragma: no cover
+                # This indicates a programming error
                 assert False, f'Do not know how to call {method_to_call}'
 
         return python_ast_to_text_ast(source)

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -91,13 +91,13 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
         q_str = self.generate_qastle(a)
         logging.getLogger(__name__).debug(f'Qastle string sent to servicex: {q_str}')
 
-        # Find the function we need to run against.
-        if a_func.id not in self._ds_map:
-            raise FuncADLServerException(f'Internal error - asked for {a_func.id} - but this dataset does not support it.')
-
         # If only qastle is wanted, return here.
         if self.return_qastle:
             return q_str
+
+        # Find the function we need to run against.
+        if a_func.id not in self._ds_map:
+            raise FuncADLServerException(f'Internal error - asked for {a_func.id} - but this dataset does not support it.')
 
         # Next, run it, depending on the function
         name = self._ds_map[a_func.id]
@@ -199,7 +199,7 @@ class ServiceXSourceUpROOT(ServiceXDatasetSourceBase):
             f_name (str): The function name we should check
         '''
         if f_name == 'ResultTTree':
-            raise FuncADLServerException('The AsROOTTTrees datatype is not supported by the xAOD backend. Please use AsParquetFiles, AsAwkward, or AsPandas')
+            raise FuncADLServerException('The AsROOTTTrees datatype is not supported by the uproot backend. Please use AsParquetFiles, AsAwkward, or AsPandas')
 
     def generate_qastle(self, a: ast.Call) -> str:
         '''Genrate the `qastle` for a query to the uproot backend

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -154,14 +154,17 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
             return q_str
 
         # Find the function we need to run against.
-        if a_func.id not in self._ds_map:
-            raise FuncADLServerException(f'Internal error - asked for {a_func.id} - but this dataset does not support it.')
+        if a_func.id in self._ds_map:
+            name = self._ds_map[a_func.id]
+        else:
+            data_type = self._ds.first_supported_datatype(['parquet', 'root'])
+            if data_type is not None and data_type in self._format_map:
+                name = self._format_map[data_type]
+            else:
+                raise FuncADLServerException(f'Internal error - asked for {a_func.id} - but this dataset does not support it.')
 
-        # Next, run it, depending on the function
-        name = self._ds_map[a_func.id]
+        # Run ghe query for real!
         attr = getattr(self._ds, name)
-
-        # Run it!
         return await attr(q_str, title=title)
 
 

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -1,11 +1,10 @@
 # Code to support running an ast at a remote func-adl server.
 import ast
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections import Iterable
 from typing import Any, Optional, Union, cast
 
-import qastle
 from func_adl import EventDataset
 from qastle import python_ast_to_text_ast
 from servicex import ServiceXDataset
@@ -21,6 +20,10 @@ class FuncADLServerException (Exception):
 class ServiceXDatasetSourceBase (EventDataset, ABC):
     '''
     Base class for a ServiceX backend dataset.
+
+    While no methods are abstract, base classes will need to add arguments
+    to the base `EventDataset` to make sure that it contains the information
+    backends expect!
     '''
     # How we map from func_adl to a servicex query
     _ds_map = {
@@ -30,24 +33,47 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
         'ResultAwkwardArray': 'get_data_awkward_async',
     }
 
-    def __init__(self, sx: ServiceXDataset):
+    # If it comes down to format, what are we going to grab?
+    _format_map = {
+        'root': 'get_data_rootfiles_async',
+        'parquet': 'get_data_parquet_async',
+    }
+
+    # These are methods that are translated locally
+    _execute_locally = ['ResultPandasDF', 'ResultAwkwardArray']
+
+    # If we have a choice of formats, what can we do, in
+    # prioritized order?
+    _format_list = ['parquet', 'root']
+
+    def __init__(self, sx: Union[ServiceXDataset, DatasetType], backend_name: str):
         '''
         Create a servicex dataset sequence from a servicex dataset
         '''
         super().__init__()
 
-        self._ds = sx
+        # Get the base created
+        if isinstance(sx, (str, Iterable)):
+            ds = ServiceXDataset(sx, backend_name=backend_name)
+        else:
+            ds = sx
+        self._ds = ds
+
         self._return_qastle = False
 
     @property
-    def return_qastle(self):
+    def return_qastle(self) -> bool:
+        '''Get/Set flag indicating if we'll generate `qastle` rather than run the query when executed.
+
+        If `True`, then execution of this query will return `qastle`, and if `False` then
+        the query will be executed.
+        '''
         return self._return_qastle
 
     @return_qastle.setter
     def return_qastle(self, value: bool):
         self._return_qastle = value
 
-    @abstractmethod
     def check_data_format_request(self, f_name: str):
         '''Check to make sure the dataformat that is getting requested is ok. Throw an error
         to give the user enough undersanding of why it isn't.
@@ -55,13 +81,21 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
         Args:
             f_name (str): The function name of the final thing we are requesting.
         '''
+        if ((f_name == 'ResultTTree' and self._ds.first_supported_datatype('root') is None)
+                or (f_name == 'ResultParquet'
+                    and self._ds.first_supported_datatype('parquet') is None)):
+            raise FuncADLServerException(f'{f_name} is not supported by {str(self._ds)}')
 
-    @abstractmethod
+        # If here, we assume the user knows what they are doing. The return format will be
+        # the default file type
+        return
+
     def generate_qastle(self, a: ast.Call) -> str:
         '''Generate the qastle from the ast of the query.
 
         1. The top level function is already marked as being "ok"
-        1. The top level function is included in this ast (you get the complete thing)
+        1. If the top level function is something we have to process locally,
+           then we strip it off.
 
         Args:
             a (ast.AST): The complete AST of the request.
@@ -69,6 +103,30 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
         Returns:
             str: Qastle that should be sent to servicex
         '''
+        top_function = cast(ast.Name, a.func).id
+        source = a
+        if top_function in self._execute_locally:
+            # Request the default type here
+            default_format = self._ds.first_supported_datatype(['parquet', 'root'])
+            assert default_format is not None, 'Unsupported ServiceX returned format'
+            method_to_call = self._format_map[default_format]
+
+            if len(a.args) != 2:
+                raise FuncADLServerException(f'Do not understand how to call {cast(ast.Name, a.func).id} - wrong number of arguments')
+            stream = a.args[0]
+            col_names = a.args[1]
+            if method_to_call == 'get_data_rootfiles_async':
+                source = ast.Call(
+                    func=ast.Name(id='ResultTTree', ctx=ast.Load()),
+                    args=[stream, col_names, ast.Str('treeme'), ast.Str('junk.root')])
+            elif method_to_call == 'get_data_parquet_async':
+                source = ast.Call(
+                    func=ast.Name(id='ResultParquet', ctx=ast.Load()),
+                    args=[stream, col_names, ast.Str('junk.parquet')])
+            else:
+                assert False, f'Do not know how to call {method_to_call}'
+
+        return python_ast_to_text_ast(source)
 
     async def execute_result_async(self, a: ast.Call, title: Optional[str] = None) -> Any:
         r'''
@@ -115,46 +173,10 @@ class ServiceXSourceCPPBase(ServiceXDatasetSourceBase):
             sx (Union[ServiceXDataset, str]): The ServiceX dataset or dataset source.
             backend_name (str): The backend type, `xaod`, for example, for the ATLAS R21 xaod
         '''
-        # Get the base created
-        if isinstance(sx, (str, Iterable)):
-            ds = ServiceXDataset(sx, backend_name=backend_name)
-        else:
-            ds = sx
-
-        super().__init__(ds)
+        super().__init__(sx, backend_name)
 
         # Add the filename
         self.query_ast.args.append(ast.Str(s='bogus.root'))  # type: ignore
-
-    def check_data_format_request(self, f_name: str):
-        '''Check to make sure things we are asking for here are ok. We really can't deal with Parquet files. Other than
-        that we are a go!
-
-        Args:
-            f_name (str): The function name we should check
-        '''
-        if f_name == 'ResultParquet':
-            raise FuncADLServerException('The AsParquetFiles datatype is not supported by the xAOD backend. Please use AsROOTTTrees, AsAwkward, or AsPandas')
-
-    def generate_qastle(self, a: ast.Call) -> str:
-        '''Genrate the `qastle` for a query to the xAOD backend
-
-        Args:
-            a (ast.AST): The query
-
-        Returns:
-            str: The `qastle`, ready to pass to the back end.
-        '''
-        # If this is a call for an awkward or pandas, then we need to convert it to a root tree array.
-        source = a
-        if cast(ast.Name, a.func).id != 'ResultTTree':
-            if len(a.args) != 2:
-                raise FuncADLServerException(f'Do not understand how to call {cast(ast.Name, a.func).id} - wrong number of arguments')
-            stream = a.args[0]
-            cols = a.args[1]
-            source = ast.Call(func=ast.Name(id='ResultTTree', ctx=ast.Load()), args=[stream, cols, ast.Str('treeme'), ast.Str('file.root')])
-
-        return python_ast_to_text_ast(source)
 
 
 class ServiceXSourceXAOD(ServiceXSourceCPPBase):
@@ -174,45 +196,13 @@ class ServiceXSourceCMSRun1AOD(ServiceXSourceCPPBase):
 
 
 class ServiceXSourceUpROOT(ServiceXDatasetSourceBase):
-    def __init__(self, sx: Union[ServiceXDataset, DatasetType], treename: str, backend='uproot'):
+    def __init__(self, sx: Union[ServiceXDataset, DatasetType], treename: str, backend_name='uproot'):
         '''
         Create a servicex dataset sequence from a servicex dataset
         '''
-        # Get the base created.
-        if isinstance(sx, (str, Iterable)):
-            ds = ServiceXDataset(sx, backend_name=backend)
-        else:
-            ds = sx
-
-        super().__init__(ds)
+        super().__init__(sx, backend_name)
 
         # Modify the argument list in EventDataSset to include a dummy filename and
         # tree name
         self.query_ast.args.append(ast.Str(s='bogus.root'))  # type: ignore
         self.query_ast.args.append(ast.Str(s=treename))  # type: ignore
-
-    def check_data_format_request(self, f_name: str):
-        '''Check to make sure things we are asking for here are ok. We really can't deal with Parquet files. Other than
-        that we are a go!
-
-        Args:
-            f_name (str): The function name we should check
-        '''
-        if f_name == 'ResultTTree':
-            raise FuncADLServerException('The AsROOTTTrees datatype is not supported by the uproot backend. Please use AsParquetFiles, AsAwkward, or AsPandas')
-
-    def generate_qastle(self, a: ast.Call) -> str:
-        '''Genrate the `qastle` for a query to the uproot backend
-
-        Args:
-            a (ast.AST): The query
-
-        Returns:
-            str: The `qastle`, ready to pass to the back end.
-        '''
-        # We need to pull the top off it - the request for the particular data type (parquet, pandas, etc.)
-        # should not get passed to the transformer.
-        source = a.args[0]
-
-        # And that is all we need!
-        return python_ast_to_text_ast(qastle.insert_linq_nodes(source))

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -48,6 +48,7 @@ def test_sx_uproot(async_mock):
 def test_sx_uproot_root(async_mock):
     'Test a request for parquet files from an xAOD guy bombs'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = None
     ds = ServiceXSourceUpROOT(sx, 'my_tree')
     q = ds.Select("lambda e: e.MET").AsROOTTTree('junk.parquet', 'another_tree', ['met'])
 
@@ -60,58 +61,63 @@ def test_sx_uproot_root(async_mock):
 def test_sx_uproot_parquet(async_mock):
     'Test a request for parquet files from an xAOD guy bombs'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = 'parquet'
     ds = ServiceXSourceUpROOT(sx, 'my_tree')
     q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
 
     q.value()
 
-    sx.get_data_parquet_async.assert_called_with("(Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))", title=None)
+    sx.get_data_parquet_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title=None)
 
 
 def test_sx_uproot_parquet_title(async_mock):
     'Test a request for parquet files from an xAOD guy bombs'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = 'parquet'
     ds = ServiceXSourceUpROOT(sx, 'my_tree')
     q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
 
     q.value(title="no way")
 
-    sx.get_data_parquet_async.assert_called_with("(Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))", title="no way")
+    sx.get_data_parquet_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title="no way")
 
 
 def test_sx_uproot_parquet_qastle(async_mock):
     'Test a request for parquet files from an xAOD guy bombs'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = 'parquet'
     ds = ServiceXSourceUpROOT(sx, 'my_tree')
     ds.return_qastle = True
     q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
 
     result = q.value()
 
-    assert result == "(Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))"
+    assert result == "(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')"
     sx.get_data_parquet_async.assert_not_called()
 
 
 def test_sx_uproot_awkward(async_mock):
     'Test a request for awkward data from an xAOD guy bombs'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = 'parquet'
     ds = ServiceXSourceUpROOT(sx, 'my_tree')
     q = ds.Select("lambda e: e.MET").AsAwkwardArray(['met'])
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))", title=None)
+    sx.get_data_awkward_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title=None)
 
 
 def test_sx_uproot_pandas(async_mock):
     'Test a request for awkward data from an xAOD guy bombs'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = 'parquet'
     ds = ServiceXSourceUpROOT(sx, 'my_tree')
     q = ds.Select("lambda e: e.MET").AsPandasDF(['met'])
 
     q.value()
 
-    sx.get_data_pandas_df_async.assert_called_with("(Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))", title=None)
+    sx.get_data_pandas_df_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title=None)
 
 
 def test_sx_xaod(async_mock):
@@ -128,6 +134,7 @@ def test_sx_xaod(async_mock):
 def test_sx_xaod_parquet(async_mock):
     'Test a request for parquet files from an xAOD guy bombs'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = None
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
 
@@ -151,23 +158,25 @@ def test_sx_xaod_root(async_mock):
 def test_sx_xaod_awkward(async_mock):
     'Test a request for awkward arrays from an xAOD backend'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = 'root'
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray(['met'])
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'file.root')", title=None)
+    sx.get_data_awkward_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'junk.root')", title=None)
 
 
 def test_sx_xaod_pandas(async_mock):
     'Test a request for awkward arrays from an xAOD backend'
     sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = 'root'
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsPandasDF(['met'])
 
     q.value()
 
-    sx.get_data_pandas_df_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'file.root')", title=None)
+    sx.get_data_pandas_df_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'junk.root')", title=None)
 
 
 def test_ctor_xaod(mocker):
@@ -208,7 +217,7 @@ def test_ctor_uproot(mocker):
 def test_ctor_uproot_alternate_backend(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
     mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
-    ServiceXSourceUpROOT('did_1221', 'a_tree', backend='myleftfoot')
+    ServiceXSourceUpROOT('did_1221', 'a_tree', backend_name='myleftfoot')
     call.assert_called_with('did_1221', backend_name='myleftfoot')
 
 

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -59,7 +59,7 @@ def test_sx_uproot_root(async_mock):
 
 
 def test_sx_uproot_parquet(async_mock):
-    'Test a request for parquet files from an xAOD guy bombs'
+    'Test a request for parquet files as parquet files works'
     sx = async_mock(spec=ServiceXDataset)
     sx.first_supported_datatype.return_value = 'parquet'
     ds = ServiceXSourceUpROOT(sx, 'my_tree')
@@ -68,6 +68,24 @@ def test_sx_uproot_parquet(async_mock):
     q.value()
 
     sx.get_data_parquet_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title=None)
+
+
+def test_sx_uproot_default(async_mock):
+    'Test a request for data as dict with no explicit output returns parquet files'
+    sx = async_mock(spec=ServiceXDataset)
+    sx.first_supported_datatype.return_value = 'parquet'
+    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    q = (
+        ds
+        .Select(lambda e: e.MET)
+        .Select(lambda met: {
+            'met': met,
+        })
+    )
+
+    q.value()
+
+    sx.get_data_parquet_async.assert_called_with("(call Select (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (lambda (list met) (dict (list 'met') (list met))))", title=None)
 
 
 def test_sx_uproot_parquet_title(async_mock):


### PR DESCRIPTION
* If you end with a Select statement or similar, assume the backend can handle it
* Automatically determine the proper way to get data driven by ServiceXDataset knowledge (rather than something determined coder).
* Removed some tests for things that just do never happen, so no need to protect
* Split the CI jobs in two - first flake8, etc., and then do the pytesting and coverage