### PR TITLE
Uproot transformer can't deal with explicit column names

### DIFF
--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -118,9 +118,11 @@ class ServiceXDatasetSourceBase (EventDataset, ABC):
                     func=ast.Name(id='ResultTTree', ctx=ast.Load()),
                     args=[stream, col_names, ast.Str('treeme'), ast.Str('junk.root')])
             elif method_to_call == 'get_data_parquet_async':
-                source = ast.Call(
-                    func=ast.Name(id='ResultParquet', ctx=ast.Load()),
-                    args=[stream, col_names, ast.Str('junk.parquet')])
+                source = stream
+                # See #32 for why this is commented out
+                # source = ast.Call(
+                #     func=ast.Name(id='ResultParquet', ctx=ast.Load()),
+                #     args=[stream, col_names, ast.Str('junk.parquet')])
             else:  # pragma: no cover
                 # This indicates a programming error
                 assert False, f'Do not know how to call {method_to_call}'

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -115,7 +115,7 @@ def test_sx_uproot_parquet_qastle(async_mock):
 
 
 def test_sx_uproot_awkward(async_mock):
-    'Test a request for awkward data from an xAOD guy bombs'
+    'Test a request for awkward data from uproot does proper request'
     sx = async_mock(spec=ServiceXDataset)
     sx.first_supported_datatype.return_value = 'parquet'
     ds = ServiceXSourceUpROOT(sx, 'my_tree')
@@ -123,7 +123,7 @@ def test_sx_uproot_awkward(async_mock):
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title=None)
+    sx.get_data_awkward_async.assert_called_with("(call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))", title=None)
 
 
 def test_sx_uproot_pandas(async_mock):
@@ -135,7 +135,7 @@ def test_sx_uproot_pandas(async_mock):
 
     q.value()
 
-    sx.get_data_pandas_df_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title=None)
+    sx.get_data_pandas_df_async.assert_called_with("(call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))", title=None)
 
 
 def test_sx_xaod(async_mock):


### PR DESCRIPTION
* When the uproot backend is invoked, do not add a AsParquet file - the uproot backend can't deal with it.

Fixes #32
