### PR TITLE
No Col Specified, No Col to access

### DIFF
--- a/func_adl_servicex/util_query_ast.py
+++ b/func_adl_servicex/util_query_ast.py
@@ -1,0 +1,45 @@
+import ast
+from typing import cast
+
+
+def has_col_names(a: ast.AST) -> bool:
+    '''Determine if any column names were specified
+    in this request.
+
+    Args:
+        a (ast.AST): The complete AST of the request.
+
+    Returns:
+        bool: True if no column names were specified, False otherwise.
+    '''
+    assert isinstance(a, ast.Call)
+    func_ast = a
+    top_function = cast(ast.Name, a.func).id
+
+    if top_function == 'ResultAwkwardArray':
+        if len(a.args) >= 2:
+            cols = a.args[1]
+            if isinstance(cols, ast.List):
+                if len(cols.elts) > 0:
+                    return True
+            elif isinstance(ast.literal_eval(cols), str):
+                return True
+        func_ast = a.args[0]
+        assert isinstance(func_ast, ast.Call)
+
+    top_function = cast(ast.Name, func_ast.func).id
+    if top_function not in ['Select', 'SelectMany']:
+        return False
+
+    # Grab the lambda and see if it is returning a dict
+    func_called = func_ast.args[1]
+    assert isinstance(func_called, ast.Lambda)
+    body = func_called.body
+    if isinstance(body, ast.Dict):
+        return True
+
+    # Ok - we didn't find evidence of column names being
+    # specified. It could still happen, but not as far
+    # as we can tell.
+
+    return False

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -235,6 +235,18 @@ def test_sx_xaod_awkward_no_column_direct(async_mock):
     assert str(ak.type(r)) == '3 * int64'
 
 
+def test_sx_xaod_awkward_col_name_direct(async_mock):
+    'Get the ak.Array directly with no dict access if we do not specify a column'
+    sx = async_mock(spec=ServiceXDataset)
+    sx.get_data_awkward_async.return_value = ak.Array({'col1': [1, 2, 3]})
+    sx.first_supported_datatype.return_value = 'root'
+    ds = ServiceXSourceXAOD(sx)
+    q = ds.Select("lambda e: e.MET").AsAwkwardArray('col1')
+
+    r = q.value()
+    assert str(ak.type(r)) == '3 * {"col1": int64}'
+
+
 def test_sx_xaod_pandas(async_mock):
     'Test a request for awkward arrays from an xAOD backend'
     sx = async_mock(spec=ServiceXDataset)

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -6,6 +6,7 @@ from typing import Optional
 import pytest
 from func_adl import ObjectStream
 from servicex import ServiceXDataset
+import awkward as ak
 
 from func_adl_servicex import (FuncADLServerException,
                                ServiceXSourceUpROOT,
@@ -212,6 +213,7 @@ def test_sx_xaod_awkward_single_dict(async_mock):
 def test_sx_xaod_awkward_no_columns(async_mock):
     'Test a request for awkward arrays from an xAOD backend'
     sx = async_mock(spec=ServiceXDataset)
+    sx.get_data_awkward_async.return_value = ak.Array({'col1': [1, 2, 3]})
     sx.first_supported_datatype.return_value = 'root'
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray()
@@ -219,6 +221,18 @@ def test_sx_xaod_awkward_no_columns(async_mock):
     q.value()
 
     sx.get_data_awkward_async.assert_called_with("(call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET')))", title=None)
+
+
+def test_sx_xaod_awkward_no_column_direct(async_mock):
+    'Get the ak.Array directly with no dict access if we do not specify a column'
+    sx = async_mock(spec=ServiceXDataset)
+    sx.get_data_awkward_async.return_value = ak.Array({'col1': [1, 2, 3]})
+    sx.first_supported_datatype.return_value = 'root'
+    ds = ServiceXSourceXAOD(sx)
+    q = ds.Select("lambda e: e.MET").AsAwkwardArray()
+
+    r = q.value()
+    assert str(ak.type(r)) == '3 * int64'
 
 
 def test_sx_xaod_pandas(async_mock):

--- a/tests/test_util_query_ast.py
+++ b/tests/test_util_query_ast.py
@@ -1,0 +1,95 @@
+
+import pytest
+from servicex import ServiceXDataset
+from func_adl_servicex.ServiceX import ServiceXSourceXAOD
+from func_adl_servicex.util_query_ast import has_col_names
+
+
+@pytest.fixture
+def async_mock(mocker):
+    import sys
+    if sys.version_info[1] <= 7:
+        import asyncmock
+        return asyncmock.MagicMock
+    else:
+        return mocker.MagicMock
+
+
+def test_col_specified(async_mock):
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+
+    query = (
+        ds
+        .Select(lambda e: {
+            'col1': e.met
+        })
+        .AsAwkwardArray()
+    )
+    assert has_col_names(query.query_ast)
+
+
+def test_col_specified_in_func(async_mock):
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+
+    def func(e):
+        return {'col1': e.met}
+
+    query = (
+        ds
+        .Select(func)
+        .AsAwkwardArray()
+    )
+    assert has_col_names(query.query_ast)
+
+
+def test_col_specified_selectmany(async_mock):
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+
+    query = (
+        ds
+        .SelectMany(lambda e: {
+            'col1': e.met
+        })
+        .AsAwkwardArray()
+    )
+    assert has_col_names(query.query_ast)
+
+
+def test_col_specified_in_awk(async_mock):
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+
+    query = (
+        ds
+        .Select(lambda e: {
+            e.met
+        })
+        .AsAwkwardArray('col1')
+    )
+    assert has_col_names(query.query_ast)
+
+
+def test_col_not_specified(async_mock):
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+
+    query = (
+        ds
+        .Select(lambda e: e.met)
+    )
+    assert not has_col_names(query.query_ast)
+
+
+def test_col_not_specified_with_AWK(async_mock):
+    sx = async_mock(spec=ServiceXDataset)
+    ds = ServiceXSourceXAOD(sx)
+
+    query = (
+        ds
+        .Select(lambda e: e.met)
+        .AsAwkwardArray()
+    )
+    assert not has_col_names(query.query_ast)


### PR DESCRIPTION
* When user asked for one column, and does not give it a name, return the array of data - so no key is required to access it!
* This will break scripts that had to do "r.col1" or similar to get at the sigle column of data

Fixes #43