### PR TITLE
Make sure AsParquetFiles works correctly with uproot

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Run Code Coverage",
             "type": "shell",
-            "command": ". .venv/scripts/activate.ps1 ; coverage-3.9.exe run -m pytest",
+            "command": ". .venv/scripts/activate.ps1 ; coverage run -m pytest",
             "problemMatcher": []
         },
     ]

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -3,58 +3,65 @@ import ast
 import logging
 from abc import ABC
 from collections.abc import Iterable
-from typing import Any, Optional, TypeVar, Union, cast
+from typing import Any, List, Optional, TypeVar, Union, cast
 
 from func_adl import EventDataset
 from qastle import python_ast_to_text_ast
 from servicex import ServiceXDataset
 from servicex.utils import DatasetType
 
-from func_adl_servicex.util_query_ast import has_col_names
+from func_adl_servicex.util_query_ast import has_col_names, has_tuple
 
 
-class FuncADLServerException (Exception):
-    'Thrown when an exception happens contacting the server'
+class FuncADLServerException(Exception):
+    "Thrown when an exception happens contacting the server"
+
     def __init__(self, msg):
         Exception.__init__(self, msg)
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 class ServiceXDatasetSourceBase(EventDataset[T], ABC):
-    '''
+    """
     Base class for a ServiceX backend dataset.
 
     While no methods are abstract, base classes will need to add arguments
     to the base `EventDataset` to make sure that it contains the information
     backends expect!
-    '''
+    """
+
     # How we map from func_adl to a servicex query
     _ds_map = {
-        'ResultTTree': 'get_data_rootfiles_async',
-        'ResultParquet': 'get_data_parquet_async',
-        'ResultPandasDF': 'get_data_pandas_df_async',
-        'ResultAwkwardArray': 'get_data_awkward_async',
+        "ResultTTree": "get_data_rootfiles_async",
+        "ResultParquet": "get_data_parquet_async",
+        "ResultPandasDF": "get_data_pandas_df_async",
+        "ResultAwkwardArray": "get_data_awkward_async",
     }
 
     # If it comes down to format, what are we going to grab?
     _format_map = {
-        'root': 'get_data_rootfiles_async',
-        'parquet': 'get_data_parquet_async',
+        "root": "get_data_rootfiles_async",
+        "parquet": "get_data_parquet_async",
     }
 
     # These are methods that are translated locally
-    _execute_locally = ['ResultPandasDF', 'ResultAwkwardArray']
+    _execute_locally = ["ResultPandasDF", "ResultAwkwardArray"]
 
     # If we have a choice of formats, what can we do, in
     # prioritized order?
-    _format_list = ['parquet', 'root']
+    _format_list = ["parquet", "root"]
 
-    def __init__(self, sx: Union[ServiceXDataset, DatasetType], backend_name: str, item_type: type = Any):
-        '''
+    def __init__(
+        self,
+        sx: Union[ServiceXDataset, DatasetType],
+        backend_name: str,
+        item_type: type = Any,
+    ):
+        """
         Create a servicex dataset sequence from a servicex dataset
-        '''
+        """
         super().__init__(item_type=item_type)
 
         # Get the base created
@@ -68,11 +75,11 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
 
     @property
     def return_qastle(self) -> bool:
-        '''Get/Set `qastle` generation flag.
+        """Get/Set `qastle` generation flag.
 
         If `True`, then execution of this query will return `qastle`, and if `False` then
         the query will be executed.
-        '''
+        """
         return self._return_qastle
 
     @return_qastle.setter
@@ -80,23 +87,29 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
         self._return_qastle = value
 
     def check_data_format_request(self, f_name: str):
-        '''Check to make sure the dataformat that is getting requested is ok. Throw an error
-        to give the user enough undersanding of why it isn't.
+        """Check to make sure the data format that is getting requested is ok. Throw an error
+        to give the user enough understanding of why it isn't.
 
         Args:
             f_name (str): The function name of the final thing we are requesting.
-        '''
-        if ((f_name == 'ResultTTree' and self._ds.first_supported_datatype('root') is None)
-                or (f_name == 'ResultParquet'
-                    and self._ds.first_supported_datatype('parquet') is None)):
-            raise FuncADLServerException(f'{f_name} is not supported by {str(self._ds)}')
+        """
+        if (
+            f_name == "ResultTTree"
+            and self._ds.first_supported_datatype("root") is None
+        ) or (
+            f_name == "ResultParquet"
+            and self._ds.first_supported_datatype("parquet") is None
+        ):
+            raise FuncADLServerException(
+                f"{f_name} is not supported by {str(self._ds)}"
+            )
 
         # If here, we assume the user knows what they are doing. The return format will be
         # the default file type
         return
 
     def generate_qastle(self, a: ast.Call) -> str:
-        '''Generate the qastle from the ast of the query.
+        """Generate the qastle from the ast of the query.
 
         1. The top level function is already marked as being "ok"
         1. If the top level function is something we have to process locally,
@@ -107,28 +120,36 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
 
         Returns:
             str: Qastle that should be sent to servicex
-        '''
+        """
         top_function = cast(ast.Name, a.func).id
         source = a
         if top_function in self._execute_locally:
             # Request the default type here
-            default_format = self._ds.first_supported_datatype(['parquet', 'root'])
-            assert default_format is not None, 'Unsupported ServiceX returned format'
+            default_format = self._ds.first_supported_datatype(["parquet", "root"])
+            assert default_format is not None, "Unsupported ServiceX returned format"
             method_to_call = self._format_map[default_format]
 
             stream = a.args[0]
             col_names = a.args[1]
-            if method_to_call == 'get_data_rootfiles_async':
+            if method_to_call == "get_data_rootfiles_async":
                 # If we have no column names, then we must be using a dictionary to set them - so just pass that
                 # directly.
-                assert isinstance(col_names, (ast.List, ast.Constant, ast.Str)), f'Programming error - type name not known {type(col_names).__name__}'
+                assert isinstance(
+                    col_names, (ast.List, ast.Constant, ast.Str)
+                ), f"Programming error - type name not known {type(col_names).__name__}"
                 if isinstance(col_names, ast.List) and len(col_names.elts) == 0:
                     source = stream
                 else:
                     source = ast.Call(
-                        func=ast.Name(id='ResultTTree', ctx=ast.Load()),
-                        args=[stream, col_names, ast.Str('treeme'), ast.Str('junk.root')])
-            elif method_to_call == 'get_data_parquet_async':
+                        func=ast.Name(id="ResultTTree", ctx=ast.Load()),
+                        args=[
+                            stream,
+                            col_names,
+                            ast.Str("treeme"),
+                            ast.Str("junk.root"),
+                        ],
+                    )
+            elif method_to_call == "get_data_parquet_async":
                 source = stream
                 # See #32 for why this is commented out
                 # source = ast.Call(
@@ -136,12 +157,61 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
                 #     args=[stream, col_names, ast.Str('junk.parquet')])
             else:  # pragma: no cover
                 # This indicates a programming error
-                assert False, f'Do not know how to call {method_to_call}'
+                assert False, f"Do not know how to call {method_to_call}"
+
+        elif top_function == "ResultParquet":
+            # Strip off the Parquet function, do a select if there are arguments for column names
+            source = a.args[0]
+            col_names = cast(ast.List, a.args[1]).elts
+
+            def encode_as_tuple_reference(c_names: List) -> List[ast.AST]:
+                # Encode each column ref as a index into the tuple we are being passed
+                return [
+                    ast.Subscript(
+                        value=ast.Name(id="x", ctx=ast.Load()),
+                        slice=ast.Constant(idx),
+                        ctx=ast.Load(),
+                    )
+                    for idx, _ in enumerate(c_names)
+                ]
+
+            def encode_as_single_reference():
+                # Single reference for a bare (non-col) variable
+                return [
+                    ast.Name(id="x", ctx=ast.Load()),
+                ]
+
+            if len(col_names) > 0:
+                # Add a select on top to set the column names
+                if len(col_names) == 1:
+                    # Determine if they built a tuple or not
+                    values = (
+                        encode_as_tuple_reference(col_names)
+                        if has_tuple(source)
+                        else encode_as_single_reference()
+                    )
+                elif len(col_names) > 1:
+                    values = encode_as_tuple_reference(col_names)
+                else:
+                    assert False, "make sure that type checkers can figure this out"
+
+                d = ast.Dict(keys=col_names, values=values)
+                tup_func = ast.Lambda(
+                    args=ast.arguments(args=[ast.arg(arg="x")]), body=d
+                )
+                c = ast.Call(
+                    func=ast.Name(id="Select", ctx=ast.Load()),
+                    args=[source, tup_func],
+                    keywords=[],
+                )
+                source = c
 
         return python_ast_to_text_ast(source)
 
-    async def execute_result_async(self, a: ast.Call, title: Optional[str] = None) -> Any:
-        r'''
+    async def execute_result_async(
+        self, a: ast.Call, title: Optional[str] = None
+    ) -> Any:
+        r"""
         Run a query against a func-adl ServiceX backend. The appropriate part of the AST is
         shipped there, and it is interpreted.
 
@@ -152,14 +222,14 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
 
         Returns:
             v                   Whatever the data that is requested (awkward arrays, etc.)
-        '''
+        """
         # Check the call is legal for this datasource.
         a_func = cast(ast.Name, a.func)
         self.check_data_format_request(a_func.id)
 
         # Get the qastle string for this query
         q_str = self.generate_qastle(a)
-        logging.getLogger(__name__).debug(f'Qastle string sent to servicex: {q_str}')
+        logging.getLogger(__name__).debug(f"Qastle string sent to servicex: {q_str}")
 
         # If only qastle is wanted, return here.
         if self.return_qastle:
@@ -169,11 +239,13 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
         if a_func.id in self._ds_map:
             name = self._ds_map[a_func.id]
         else:
-            data_type = self._ds.first_supported_datatype(['parquet', 'root'])
+            data_type = self._ds.first_supported_datatype(["parquet", "root"])
             if data_type is not None and data_type in self._format_map:
                 name = self._format_map[data_type]
             else:
-                raise FuncADLServerException(f'Internal error - asked for {a_func.id} - but this dataset does not support it.')
+                raise FuncADLServerException(
+                    f"Internal error - asked for {a_func.id} - but this dataset does not support it."
+                )
 
         # Run the query for real!
         attr = getattr(self._ds, name)
@@ -181,50 +253,75 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
 
         # If this is a single column awkward query, and the user did not specify a column name, then
         # we will return the first column.
-        if 'awkward' in name and (not has_col_names(a)) and 'key="col1"' in str(result.layout):
-            result = result['col1']
+        if (
+            "awkward" in name
+            and (not has_col_names(a))
+            and 'key="col1"' in str(result.layout)
+        ):
+            result = result["col1"]
 
         return result
 
 
 class ServiceXSourceCPPBase(ServiceXDatasetSourceBase[T]):
-    def __init__(self, sx: Union[ServiceXDataset, DatasetType], backend_name: str, item_type: type = Any):
-        '''Create a C++ backend data set source
+    def __init__(
+        self,
+        sx: Union[ServiceXDataset, DatasetType],
+        backend_name: str,
+        item_type: type = Any,
+    ):
+        """Create a C++ backend data set source
 
         Args:
             sx (Union[ServiceXDataset, str]): The ServiceX dataset or dataset source.
             backend_name (str): The backend type, `xaod`, for example, for the ATLAS R21 xaod
-        '''
+        """
         super().__init__(sx, backend_name, item_type)
 
         # Add the filename
-        self.query_ast.args.append(ast.Str(s='bogus.root'))  # type: ignore
+        self.query_ast.args.append(ast.Str(s="bogus.root"))  # type: ignore
 
 
 class ServiceXSourceXAOD(ServiceXSourceCPPBase[T]):
-    def __init__(self, sx: Union[ServiceXDataset, DatasetType], backend='xaod', item_type: type = Any):
-        '''
+    def __init__(
+        self,
+        sx: Union[ServiceXDataset, DatasetType],
+        backend="xaod",
+        item_type: type = Any,
+    ):
+        """
         Create a servicex dataset sequence from a servicex dataset
-        '''
+        """
         super().__init__(sx, backend, item_type)
 
 
 class ServiceXSourceCMSRun1AOD(ServiceXSourceCPPBase[T]):
-    def __init__(self, sx: Union[ServiceXDataset, DatasetType], backend='cms_run1_aod', item_type: type = Any):
-        '''
+    def __init__(
+        self,
+        sx: Union[ServiceXDataset, DatasetType],
+        backend="cms_run1_aod",
+        item_type: type = Any,
+    ):
+        """
         Create a servicex dataset sequence from a servicex dataset
-        '''
+        """
         super().__init__(sx, backend, item_type)
 
 
 class ServiceXSourceUpROOT(ServiceXDatasetSourceBase[T]):
-    def __init__(self, sx: Union[ServiceXDataset, DatasetType], treename: str, backend_name='uproot', item_type: type = Any):
-        '''
+    def __init__(
+        self,
+        sx: Union[ServiceXDataset, DatasetType],
+        treename: str,
+        backend_name="uproot",
+        item_type: type = Any,
+    ):
+        """
         Create a servicex dataset sequence from a servicex dataset
-        '''
+        """
         super().__init__(sx, backend_name, item_type)
 
         # Modify the argument list in EventDataSset to include a dummy filename and
         # tree name
-        self.query_ast.args.append(ast.Str(s='bogus.root'))  # type: ignore
+        self.query_ast.args.append(ast.Str(s="bogus.root"))  # type: ignore
         self.query_ast.args.append(ast.Str(s=treename))  # type: ignore

--- a/func_adl_servicex/util_query_ast.py
+++ b/func_adl_servicex/util_query_ast.py
@@ -1,9 +1,9 @@
 import ast
-from typing import cast
+from typing import Optional, cast
 
 
 def has_col_names(a: ast.AST) -> bool:
-    '''Determine if any column names were specified
+    """Determine if any column names were specified
     in this request.
 
     Args:
@@ -11,12 +11,12 @@ def has_col_names(a: ast.AST) -> bool:
 
     Returns:
         bool: True if no column names were specified, False otherwise.
-    '''
+    """
     assert isinstance(a, ast.Call)
     func_ast = a
     top_function = cast(ast.Name, a.func).id
 
-    if top_function == 'ResultAwkwardArray':
+    if top_function == "ResultAwkwardArray":
         if len(a.args) >= 2:
             cols = a.args[1]
             if isinstance(cols, ast.List):
@@ -28,7 +28,7 @@ def has_col_names(a: ast.AST) -> bool:
         assert isinstance(func_ast, ast.Call)
 
     top_function = cast(ast.Name, func_ast.func).id
-    if top_function not in ['Select', 'SelectMany']:
+    if top_function not in ["Select", "SelectMany"]:
         return False
 
     # Grab the lambda and see if it is returning a dict
@@ -43,3 +43,36 @@ def has_col_names(a: ast.AST) -> bool:
     # as we can tell.
 
     return False
+
+
+def has_tuple(a: ast.AST) -> bool:
+    """Determine if this query used tuples in its final result
+
+    NOTE: This can't do depth searches in a really complex
+    query - then you need to follow best practices.
+
+    Args:
+        a (ast.AST): The query
+
+    Returns:
+        bool: True if the final Select statement has tuples or not.
+    """
+
+    def find_Select(a: ast.AST) -> Optional[ast.Call]:
+        # Descent the call chain until we find a Select.
+        while isinstance(a, ast.Call):
+            if isinstance(a.func, ast.Name):
+                if cast(ast.Name, a.func).id == "Select":
+                    return a
+            a = a.args[0]
+        return None
+
+    select_statement = find_Select(a)
+    if select_statement is None:
+        return False
+
+    # Ok - we have a select statement. Now we need to see if it is returning a tuple.
+    func_called = select_statement.args[1]
+    assert isinstance(func_called, ast.Lambda)
+    body = func_called.body
+    return isinstance(body, ast.Tuple)

--- a/setup.py
+++ b/setup.py
@@ -7,67 +7,66 @@ import os
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = os.getenv('func_adl_servicex_version')
+version = os.getenv("func_adl_servicex_version")
 if version is None:
-    version = '0.1a1'
+    version = "0.1a1"
 else:
-    version = version.split('/')[-1]
+    version = version.split("/")[-1]
 
-setup(name="func_adl_servicex",
-      version=version,
-      packages=['func_adl_servicex'],
-      scripts=[],
-      description="Submit Functional Queries to a ServiceX endpoint.",
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      author="G. Watts (IRIS-HEP/UW Seattle)",
-      author_email="gwatts@uw.edu",
-      maintainer="Gordon Watts (IRIS-HEP/UW Seattle)",
-      maintainer_email="gwatts@uw.edu",
-      url="https://github.com/iris-hep/func_adl_servicex",
-      license="TBD",
-      test_suite="tests",
-      install_requires=[
-          "func_adl>=3.0b1",
-          "qastle>=0.10, <1.0",
-          "servicex>=2.4, <3.0a1"
-      ],
-      extras_require={
-          'test': [
-              'pytest>=3.9',
-              'pytest-asyncio',
-              'pytest-mock',
-              'pytest-cov',
-              'coverage',
-              'flake8',
-              'codecov',
-              'autopep8',
-              'twine',
-              'testfixtures',
-              'wheel',
-              'asyncmock'
-          ],
-          'local': [
-              'func_adl_xAOD[local]>=2.0b1',
-          ],
-      },
-      classifiers=[
-          # "Development Status :: 3 - Alpha",
-          "Development Status :: 4 - Beta",
-          # "Development Status :: 5 - Production/Stable",
-          # "Development Status :: 6 - Mature",
-          "Intended Audience :: Developers",
-          "Intended Audience :: Information Technology",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 3.9",
-          "Programming Language :: Python :: 3.8",
-          "Programming Language :: Python :: 3.7",
-          "Topic :: Software Development",
-          "Topic :: Utilities",
-      ],
-      package_data={
-          'func_adl_xAOD/backend': ['R21Code/*'],
-      },
-      platforms="Any",
-      python_requires='>=3.7',
-      )
+setup(
+    name="func_adl_servicex",
+    version=version,
+    packages=["func_adl_servicex"],
+    scripts=[],
+    description="Submit Functional Queries to a ServiceX endpoint.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="G. Watts (IRIS-HEP/UW Seattle)",
+    author_email="gwatts@uw.edu",
+    maintainer="Gordon Watts (IRIS-HEP/UW Seattle)",
+    maintainer_email="gwatts@uw.edu",
+    url="https://github.com/iris-hep/func_adl_servicex",
+    license="TBD",
+    test_suite="tests",
+    install_requires=["func_adl>=3.0b1", "qastle>=0.10, <1.0", "servicex>=2.4, <3.0a1"],
+    extras_require={
+        "test": [
+            "pytest>=3.9",
+            "pytest-asyncio",
+            "pytest-mock",
+            "pytest-cov",
+            "coverage",
+            "flake8",
+            "codecov",
+            "autopep8",
+            "twine",
+            "testfixtures",
+            "wheel",
+            "asyncmock",
+            "black",
+        ],
+        "local": [
+            "func_adl_xAOD[local]>=2.0b1",
+        ],
+    },
+    classifiers=[
+        # "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
+        # "Development Status :: 5 - Production/Stable",
+        # "Development Status :: 6 - Mature",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Information Technology",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Software Development",
+        "Topic :: Utilities",
+    ],
+    package_data={
+        "func_adl_xAOD/backend": ["R21Code/*"],
+    },
+    platforms="Any",
+    python_requires=">=3.7",
+)

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -8,10 +8,12 @@ from func_adl import ObjectStream
 from servicex import ServiceXDataset
 import awkward as ak
 
-from func_adl_servicex import (FuncADLServerException,
-                               ServiceXSourceUpROOT,
-                               ServiceXSourceCMSRun1AOD,
-                               ServiceXSourceXAOD)
+from func_adl_servicex import (
+    FuncADLServerException,
+    ServiceXSourceUpROOT,
+    ServiceXSourceCMSRun1AOD,
+    ServiceXSourceXAOD,
+)
 
 
 async def do_exe(a, title: Optional[str] = None):
@@ -21,309 +23,358 @@ async def do_exe(a, title: Optional[str] = None):
 @pytest.fixture
 def async_mock(mocker):
     import sys
+
     if sys.version_info[1] <= 7:
         import asyncmock
+
         return asyncmock.MagicMock
     else:
         return mocker.MagicMock
 
 
 def test_sx_abs(mocker):
-    'Make sure that we cannot build the abstract base class'
+    "Make sure that we cannot build the abstract base class"
     sx = mocker.MagicMock(spec=ServiceXDataset)
     with pytest.raises(Exception):
         ServiceXDatasetSourceBase(sx)  # type: ignore
 
 
 def test_sx_uproot(async_mock):
-    'Make sure we turn the execution into a call with an uproot'
+    "Make sure we turn the execution into a call with an uproot"
     sx = async_mock(spec=ServiceXDataset)
-    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    ds = ServiceXSourceUpROOT(sx, "my_tree")
     a = ds.value(executor=do_exe)
     if sys.version_info < (3, 8):
-        assert ast.dump(a) == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Str(s='bogus.root'), Str(s='my_tree')], keywords=[])"
+        assert (
+            ast.dump(a)
+            == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Str(s='bogus.root'), Str(s='my_tree')], keywords=[])"
+        )
     else:
-        assert ast.dump(a) == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Constant(value='bogus.root'), Constant(value='my_tree')], keywords=[])"
+        assert (
+            ast.dump(a)
+            == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Constant(value='bogus.root'), Constant(value='my_tree')], keywords=[])"
+        )
 
 
 def test_sx_uproot_root(async_mock):
-    'Test a request for parquet files from an xAOD guy bombs'
+    "Test a request for parquet files from an xAOD guy bombs"
     sx = async_mock(spec=ServiceXDataset)
     sx.first_supported_datatype.return_value = None
-    ds = ServiceXSourceUpROOT(sx, 'my_tree')
-    q = ds.Select("lambda e: e.MET").AsROOTTTree('junk.parquet', 'another_tree', ['met'])
+    ds = ServiceXSourceUpROOT(sx, "my_tree")
+    q = ds.Select("lambda e: e.MET").AsROOTTTree(
+        "junk.parquet", "another_tree", ["met"]
+    )
 
     with pytest.raises(FuncADLServerException) as e:
         q.value()
 
-    assert 'not supported' in str(e.value)
+    assert "not supported" in str(e.value)
 
 
 def test_sx_uproot_parquet(async_mock):
-    'Test a request for parquet files as parquet files works'
+    "Test a request for parquet files as parquet files works"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'parquet'
-    ds = ServiceXSourceUpROOT(sx, 'my_tree')
-    q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
+    sx.first_supported_datatype.return_value = "parquet"
+    ds = ServiceXSourceUpROOT(sx, "my_tree")
+    q = ds.Select("lambda e: e.MET").AsParquetFiles("junk.parquet", ["met"])
 
     q.value()
 
-    sx.get_data_parquet_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title=None)
+    sx.get_data_parquet_async.assert_called_with(
+        "(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')",
+        title=None,
+    )
 
 
 def test_sx_uproot_default(async_mock):
-    'Test a request for data as dict with no explicit output returns parquet files'
+    "Test a request for data as dict with no explicit output returns parquet files"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'parquet'
-    ds = ServiceXSourceUpROOT(sx, 'my_tree')
-    q = (
-        ds
-        .Select(lambda e: e.MET)
-        .Select(lambda met: {
-            'met': met,
-        })
+    sx.first_supported_datatype.return_value = "parquet"
+    ds = ServiceXSourceUpROOT(sx, "my_tree")
+    q = ds.Select(lambda e: e.MET).Select(
+        lambda met: {
+            "met": met,
+        }
     )
 
     q.value()
 
-    sx.get_data_parquet_async.assert_called_with("(call Select (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (lambda (list met) (dict (list 'met') (list met))))", title=None)
+    sx.get_data_parquet_async.assert_called_with(
+        "(call Select (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (lambda (list met) (dict (list 'met') (list met))))",
+        title=None,
+    )
 
 
 def test_sx_uproot_parquet_title(async_mock):
-    'Test a request for parquet files from an xAOD guy bombs'
+    "Test a request for parquet files from an xAOD guy bombs"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'parquet'
-    ds = ServiceXSourceUpROOT(sx, 'my_tree')
-    q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
+    sx.first_supported_datatype.return_value = "parquet"
+    ds = ServiceXSourceUpROOT(sx, "my_tree")
+    q = ds.Select("lambda e: e.MET").AsParquetFiles("junk.parquet", ["met"])
 
     q.value(title="no way")
 
-    sx.get_data_parquet_async.assert_called_with("(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')", title="no way")
+    sx.get_data_parquet_async.assert_called_with(
+        "(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')",
+        title="no way",
+    )
 
 
 def test_sx_uproot_parquet_qastle(async_mock):
-    'Test a request for parquet files from an xAOD guy bombs'
+    "Test a request for parquet files from an xAOD guy bombs"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'parquet'
-    ds = ServiceXSourceUpROOT(sx, 'my_tree')
+    sx.first_supported_datatype.return_value = "parquet"
+    ds = ServiceXSourceUpROOT(sx, "my_tree")
     ds.return_qastle = True
-    q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
+    q = ds.Select("lambda e: e.MET").AsParquetFiles("junk.parquet", ["met"])
 
     result = q.value()
 
-    assert result == "(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')"
+    assert (
+        result
+        == "(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')"
+    )
     sx.get_data_parquet_async.assert_not_called()
 
 
 def test_sx_uproot_awkward(async_mock):
-    'Test a request for awkward data from uproot does proper request'
+    "Test a request for awkward data from uproot does proper request"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'parquet'
-    ds = ServiceXSourceUpROOT(sx, 'my_tree')
-    q = ds.Select("lambda e: e.MET").AsAwkwardArray(['met'])
+    sx.first_supported_datatype.return_value = "parquet"
+    ds = ServiceXSourceUpROOT(sx, "my_tree")
+    q = ds.Select("lambda e: e.MET").AsAwkwardArray(["met"])
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))", title=None)
+    sx.get_data_awkward_async.assert_called_with(
+        "(call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))",
+        title=None,
+    )
 
 
 def test_sx_uproot_pandas(async_mock):
-    'Test a request for awkward data from an xAOD guy bombs'
+    "Test a request for awkward data from an xAOD guy bombs"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'parquet'
-    ds = ServiceXSourceUpROOT(sx, 'my_tree')
-    q = ds.Select("lambda e: e.MET").AsPandasDF(['met'])
+    sx.first_supported_datatype.return_value = "parquet"
+    ds = ServiceXSourceUpROOT(sx, "my_tree")
+    q = ds.Select("lambda e: e.MET").AsPandasDF(["met"])
 
     q.value()
 
-    sx.get_data_pandas_df_async.assert_called_with("(call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))", title=None)
+    sx.get_data_pandas_df_async.assert_called_with(
+        "(call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET')))",
+        title=None,
+    )
 
 
 def test_sx_xaod(async_mock):
-    'Make sure we turn the execution into a call with an uproot'
+    "Make sure we turn the execution into a call with an uproot"
     sx = async_mock(spec=ServiceXDataset)
     ds = ServiceXSourceXAOD(sx)
     a = ds.value(executor=do_exe)
     if sys.version_info < (3, 8):
-        assert ast.dump(a) == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Str(s='bogus.root')], keywords=[])"
+        assert (
+            ast.dump(a)
+            == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Str(s='bogus.root')], keywords=[])"
+        )
     else:
-        assert ast.dump(a) == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Constant(value='bogus.root')], keywords=[])"
+        assert (
+            ast.dump(a)
+            == "Call(func=Name(id='EventDataset', ctx=Load()), args=[Constant(value='bogus.root')], keywords=[])"
+        )
 
 
 def test_sx_xaod_parquet(async_mock):
-    'Test a request for parquet files from an xAOD guy bombs'
+    "Test a request for parquet files from an xAOD guy bombs"
     sx = async_mock(spec=ServiceXDataset)
     sx.first_supported_datatype.return_value = None
     ds = ServiceXSourceXAOD(sx)
-    q = ds.Select("lambda e: e.MET").AsParquetFiles('junk.parquet', ['met'])
+    q = ds.Select("lambda e: e.MET").AsParquetFiles("junk.parquet", ["met"])
 
     with pytest.raises(FuncADLServerException) as e:
         q.value()
 
-    assert 'not supported' in str(e.value)
+    assert "not supported" in str(e.value)
 
 
 def test_sx_xaod_root(async_mock):
-    'Test a request for root files from an xAOD guy'
+    "Test a request for root files from an xAOD guy"
     sx = async_mock(spec=ServiceXDataset)
     ds = ServiceXSourceXAOD(sx)
-    q = ds.Select("lambda e: e.MET").AsROOTTTree('junk.root', 'my_tree', ['met'])
+    q = ds.Select("lambda e: e.MET").AsROOTTTree("junk.root", "my_tree", ["met"])
 
     q.value()
 
-    sx.get_data_rootfiles_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'my_tree' 'junk.root')", title=None)
+    sx.get_data_rootfiles_async.assert_called_with(
+        "(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'my_tree' 'junk.root')",
+        title=None,
+    )
 
 
 def test_sx_xaod_awkward(async_mock):
-    'Test a request for awkward arrays from an xAOD backend'
+    "Test a request for awkward arrays from an xAOD backend"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'root'
+    sx.first_supported_datatype.return_value = "root"
     ds = ServiceXSourceXAOD(sx)
-    q = ds.Select("lambda e: e.MET").AsAwkwardArray(['met'])
+    q = ds.Select("lambda e: e.MET").AsAwkwardArray(["met"])
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'junk.root')", title=None)
+    sx.get_data_awkward_async.assert_called_with(
+        "(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'junk.root')",
+        title=None,
+    )
 
 
 def test_sx_xaod_awkward_single_column(async_mock):
-    'Test a request for awkward arrays from an xAOD backend, as column name'
+    "Test a request for awkward arrays from an xAOD backend, as column name"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'root'
+    sx.first_supported_datatype.return_value = "root"
     ds = ServiceXSourceXAOD(sx)
-    q = ds.Select("lambda e: e.MET").AsAwkwardArray('met')
+    q = ds.Select("lambda e: e.MET").AsAwkwardArray("met")
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) 'met' 'treeme' 'junk.root')", title=None)
+    sx.get_data_awkward_async.assert_called_with(
+        "(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'junk.root')",
+        title=None,
+    )
 
 
 def test_sx_xaod_awkward_single_dict(async_mock):
-    'Test a request for awkward arrays from an xAOD backend, as dict labelting'
+    "Test a request for awkward arrays from an xAOD backend, as dict labelting"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'root'
+    sx.first_supported_datatype.return_value = "root"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: {'met': e.MET}").AsAwkwardArray()
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(call Select (call EventDataset 'bogus.root') (lambda (list e) (dict (list 'met') (list (attr e 'MET')))))", title=None)
+    sx.get_data_awkward_async.assert_called_with(
+        "(call Select (call EventDataset 'bogus.root') (lambda (list e) (dict (list 'met') (list (attr e 'MET')))))",
+        title=None,
+    )
 
 
 def test_sx_xaod_awkward_no_columns(async_mock):
-    'Test a request for awkward arrays from an xAOD backend'
+    "Test a request for awkward arrays from an xAOD backend"
     sx = async_mock(spec=ServiceXDataset)
-    sx.get_data_awkward_async.return_value = ak.Array({'col1': [1, 2, 3]})
-    sx.first_supported_datatype.return_value = 'root'
+    sx.get_data_awkward_async.return_value = ak.Array({"col1": [1, 2, 3]})
+    sx.first_supported_datatype.return_value = "root"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray()
 
     q.value()
 
-    sx.get_data_awkward_async.assert_called_with("(call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET')))", title=None)
+    sx.get_data_awkward_async.assert_called_with(
+        "(call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET')))",
+        title=None,
+    )
 
 
 def test_sx_xaod_awkward_no_column_direct(async_mock):
-    'Get the ak.Array directly with no dict access if we do not specify a column'
+    "Get the ak.Array directly with no dict access if we do not specify a column"
     sx = async_mock(spec=ServiceXDataset)
-    sx.get_data_awkward_async.return_value = ak.Array({'col1': [1, 2, 3]})
-    sx.first_supported_datatype.return_value = 'root'
+    sx.get_data_awkward_async.return_value = ak.Array({"col1": [1, 2, 3]})
+    sx.first_supported_datatype.return_value = "root"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray()
 
     r = q.value()
-    assert str(ak.type(r)) == '3 * int64'
+    assert str(ak.type(r)) == "3 * int64"
 
 
 def test_sx_xaod_awkward_col_name_direct(async_mock):
-    'Get the ak.Array directly with no dict access if we do not specify a column'
+    "Get the ak.Array directly with no dict access if we do not specify a column"
     sx = async_mock(spec=ServiceXDataset)
-    sx.get_data_awkward_async.return_value = ak.Array({'col1': [1, 2, 3]})
-    sx.first_supported_datatype.return_value = 'root'
+    sx.get_data_awkward_async.return_value = ak.Array({"col1": [1, 2, 3]})
+    sx.first_supported_datatype.return_value = "root"
     ds = ServiceXSourceXAOD(sx)
-    q = ds.Select("lambda e: e.MET").AsAwkwardArray('col1')
+    q = ds.Select("lambda e: e.MET").AsAwkwardArray("col1")
 
     r = q.value()
     assert str(ak.type(r)) == '3 * {"col1": int64}'
 
 
 def test_sx_xaod_pandas(async_mock):
-    'Test a request for awkward arrays from an xAOD backend'
+    "Test a request for awkward arrays from an xAOD backend"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = 'root'
+    sx.first_supported_datatype.return_value = "root"
     ds = ServiceXSourceXAOD(sx)
-    q = ds.Select("lambda e: e.MET").AsPandasDF(['met'])
+    q = ds.Select("lambda e: e.MET").AsPandasDF(["met"])
 
     q.value()
 
-    sx.get_data_pandas_df_async.assert_called_with("(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'junk.root')", title=None)
+    sx.get_data_pandas_df_async.assert_called_with(
+        "(call ResultTTree (call Select (call EventDataset 'bogus.root') (lambda (list e) (attr e 'MET'))) (list 'met') 'treeme' 'junk.root')",
+        title=None,
+    )
 
 
 def test_ctor_xaod(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
-    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
-    ServiceXSourceXAOD('did_1221')
-    call.assert_called_with('did_1221', backend_name='xaod')
+    mocker.patch("func_adl_servicex.ServiceX.ServiceXDataset", call)
+    ServiceXSourceXAOD("did_1221")
+    call.assert_called_with("did_1221", backend_name="xaod")
 
 
 def test_ctor_xaod_alternate_backend(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
-    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
-    ServiceXSourceXAOD('did_1221', backend='myleftfoot')
-    call.assert_called_with('did_1221', backend_name='myleftfoot')
+    mocker.patch("func_adl_servicex.ServiceX.ServiceXDataset", call)
+    ServiceXSourceXAOD("did_1221", backend="myleftfoot")
+    call.assert_called_with("did_1221", backend_name="myleftfoot")
 
 
 def test_ctor_cms(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
-    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
-    ServiceXSourceCMSRun1AOD('did_1221')
-    call.assert_called_with('did_1221', backend_name='cms_run1_aod')
+    mocker.patch("func_adl_servicex.ServiceX.ServiceXDataset", call)
+    ServiceXSourceCMSRun1AOD("did_1221")
+    call.assert_called_with("did_1221", backend_name="cms_run1_aod")
 
 
 def test_ctor_cms_alternate_backend(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
-    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
-    ServiceXSourceCMSRun1AOD('did_1221', backend='fork')
-    call.assert_called_with('did_1221', backend_name='fork')
+    mocker.patch("func_adl_servicex.ServiceX.ServiceXDataset", call)
+    ServiceXSourceCMSRun1AOD("did_1221", backend="fork")
+    call.assert_called_with("did_1221", backend_name="fork")
 
 
 def test_ctor_uproot(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
-    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
-    ServiceXSourceUpROOT('did_1221', 'a_tree')
-    call.assert_called_with('did_1221', backend_name='uproot')
+    mocker.patch("func_adl_servicex.ServiceX.ServiceXDataset", call)
+    ServiceXSourceUpROOT("did_1221", "a_tree")
+    call.assert_called_with("did_1221", backend_name="uproot")
 
 
 def test_ctor_uproot_alternate_backend(mocker):
     call = mocker.MagicMock(return_value=mocker.MagicMock(spec=ServiceXDataset))
-    mocker.patch('func_adl_servicex.ServiceX.ServiceXDataset', call)
-    ServiceXSourceUpROOT('did_1221', 'a_tree', backend_name='myleftfoot')
-    call.assert_called_with('did_1221', backend_name='myleftfoot')
+    mocker.patch("func_adl_servicex.ServiceX.ServiceXDataset", call)
+    ServiceXSourceUpROOT("did_1221", "a_tree", backend_name="myleftfoot")
+    call.assert_called_with("did_1221", backend_name="myleftfoot")
 
 
 def test_bad_wrong_call_name_right_args(async_mock):
-    'A call needs to be vs a Name node, not something else?'
+    "A call needs to be vs a Name node, not something else?"
     sx = async_mock(spec=ServiceXDataset)
     ds = ServiceXSourceXAOD(sx)
     next = ast.Call(
-        func=ast.Name(id='ResultBogus', ctx=ast.Load()),
-        args=[ds.query_ast, ast.Name(id='cos', ctx=ast.Load())])
+        func=ast.Name(id="ResultBogus", ctx=ast.Load()),
+        args=[ds.query_ast, ast.Name(id="cos", ctx=ast.Load())],
+    )
 
     with pytest.raises(FuncADLServerException) as e:
-        ObjectStream(next) \
-            .value()
+        ObjectStream(next).value()
 
     assert "ResultBogus" in str(e.value)
 
 
 def test_bad_wrong_call_name(async_mock):
-    'A call needs to be vs a Name node, not something else?'
+    "A call needs to be vs a Name node, not something else?"
     sx = async_mock(spec=ServiceXDataset)
     ds = ServiceXSourceXAOD(sx)
-    next = ast.Call(func=ast.Name(id='ResultBogus'), args=[ds.query_ast])
+    next = ast.Call(func=ast.Name(id="ResultBogus"), args=[ds.query_ast])
 
     with pytest.raises(FuncADLServerException) as e:
-        ObjectStream(next) \
-            .value()
+        ObjectStream(next).value()
 
     assert "ResultBogus" in str(e.value)

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -226,8 +226,17 @@ def test_sx_uproot_parquet_title(async_mock):
 
     q.value(title="no way")
 
+    actual_call = python_ast_to_text_ast(
+        cast(
+            ast.Expr,
+            ast.parse(
+                "Select(Select(EventDataset('bogus.root', 'my_tree'), lambda e: e.MET), lambda x: {'met': x})"
+            ).body[0],
+        ).value
+    )
+
     sx.get_data_parquet_async.assert_called_with(
-        "(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')",
+        actual_call,
         title="no way",
     )
 
@@ -242,10 +251,16 @@ def test_sx_uproot_parquet_qastle(async_mock):
 
     result = q.value()
 
-    assert (
-        result
-        == "(call ResultParquet (call Select (call EventDataset 'bogus.root' 'my_tree') (lambda (list e) (attr e 'MET'))) (list 'met') 'junk.parquet')"
+    actual_call = python_ast_to_text_ast(
+        cast(
+            ast.Expr,
+            ast.parse(
+                "Select(Select(EventDataset('bogus.root', 'my_tree'), lambda e: e.MET), lambda x: {'met': x})"
+            ).body[0],
+        ).value
     )
+
+    assert result == actual_call
     sx.get_data_parquet_async.assert_not_called()
 
 


### PR DESCRIPTION
* Fixes #52 - AsParquetFiles now works properly with uproot
* Technical Debt:
   * Fixed up some tests to make them more robust
   * Black is now pulled for the dev version of this
   * `vscode` coverage task now work with latest version of `coverage`.

For the future:

* We need to change the symantics of the AsParquetFiles and AsROOTFiles - with a depreciation warning of some sort. No column names shoudl be in here - use a dict instead. This is a [future change](https://github.com/iris-hep/func_adl/issues/71).