### PR TITLE
Be consistent about root file type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
         "Powheg",
         "pytest",
         "qastle",
+        "rootfiles",
         "ROOTT",
         "servicex",
         "setuptools",
@@ -25,6 +26,7 @@
         "STDM",
         "Topo",
         "treeme",
+        "treename",
         "ttbar",
         "unittests",
         "xaod"

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -42,7 +42,7 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
 
     # If it comes down to format, what are we going to grab?
     _format_map = {
-        "root": "get_data_rootfiles_async",
+        "root-file": "get_data_rootfiles_async",
         "parquet": "get_data_parquet_async",
     }
 
@@ -51,7 +51,7 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
 
     # If we have a choice of formats, what can we do, in
     # prioritized order?
-    _format_list = ["parquet", "root"]
+    _format_list = ["parquet", "root-file"]
 
     def __init__(
         self,
@@ -95,7 +95,7 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
         """
         if (
             f_name == "ResultTTree"
-            and self._ds.first_supported_datatype("root") is None
+            and self._ds.first_supported_datatype("root-file") is None
         ) or (
             f_name == "ResultParquet"
             and self._ds.first_supported_datatype("parquet") is None
@@ -125,7 +125,7 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
         source = a
         if top_function in self._execute_locally:
             # Request the default type here
-            default_format = self._ds.first_supported_datatype(["parquet", "root"])
+            default_format = self._ds.first_supported_datatype(["parquet", "root-file"])
             assert default_format is not None, "Unsupported ServiceX returned format"
             method_to_call = self._format_map[default_format]
 
@@ -239,7 +239,7 @@ class ServiceXDatasetSourceBase(EventDataset[T], ABC):
         if a_func.id in self._ds_map:
             name = self._ds_map[a_func.id]
         else:
-            data_type = self._ds.first_supported_datatype(["parquet", "root"])
+            data_type = self._ds.first_supported_datatype(["parquet", "root-file"])
             if data_type is not None and data_type in self._format_map:
                 name = self._format_map[data_type]
             else:

--- a/func_adl_servicex/ServiceX.py
+++ b/func_adl_servicex/ServiceX.py
@@ -321,7 +321,7 @@ class ServiceXSourceUpROOT(ServiceXDatasetSourceBase[T]):
         """
         super().__init__(sx, backend_name, item_type)
 
-        # Modify the argument list in EventDataSset to include a dummy filename and
+        # Modify the argument list in EventDataSet to include a dummy filename and
         # tree name
         self.query_ast.args.append(ast.Str(s="bogus.root"))  # type: ignore
         self.query_ast.args.append(ast.Str(s=treename))  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     url="https://github.com/iris-hep/func_adl_servicex",
     license="TBD",
     test_suite="tests",
-    install_requires=["func_adl>=3.0b1", "qastle>=0.10, <1.0", "servicex>=2.4, <3.0a1"],
+    install_requires=["func_adl>=3.2", "qastle>=0.10", "servicex>=2.6.1b1"],
     extras_require={
         "test": [
             "pytest>=3.9",
@@ -46,7 +46,7 @@ setup(
             "black",
         ],
         "local": [
-            "func_adl_xAOD[local]>=2.0b1",
+            "func_adl_xAOD[local]>=2.6b3",
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     url="https://github.com/iris-hep/func_adl_servicex",
     license="TBD",
     test_suite="tests",
-    install_requires=["func_adl>=3.2", "qastle>=0.10", "servicex>=2.6.1b1"],
+    install_requires=["func_adl>=3.2", "qastle>=0.10", "servicex>=2.6.1b1,<2.6.2"],
     extras_require={
         "test": [
             "pytest>=3.9",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             "black",
         ],
         "local": [
-            "func_adl_xAOD[local]>=2.6b3",
+            "func_adl_xAOD[local]",
         ],
     },
     classifiers=[

--- a/tests/test_ServiceX.py
+++ b/tests/test_ServiceX.py
@@ -341,7 +341,7 @@ def test_sx_xaod_root(async_mock):
 def test_sx_xaod_awkward(async_mock):
     "Test a request for awkward arrays from an xAOD backend"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = "root"
+    sx.first_supported_datatype.return_value = "root-file"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray(["met"])
 
@@ -356,7 +356,7 @@ def test_sx_xaod_awkward(async_mock):
 def test_sx_xaod_awkward_single_column(async_mock):
     "Test a request for awkward arrays from an xAOD backend, as column name"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = "root"
+    sx.first_supported_datatype.return_value = "root-file"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray("met")
 
@@ -371,7 +371,7 @@ def test_sx_xaod_awkward_single_column(async_mock):
 def test_sx_xaod_awkward_single_dict(async_mock):
     "Test a request for awkward arrays from an xAOD backend, as dict labelting"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = "root"
+    sx.first_supported_datatype.return_value = "root-file"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: {'met': e.MET}").AsAwkwardArray()
 
@@ -387,7 +387,7 @@ def test_sx_xaod_awkward_no_columns(async_mock):
     "Test a request for awkward arrays from an xAOD backend"
     sx = async_mock(spec=ServiceXDataset)
     sx.get_data_awkward_async.return_value = ak.Array({"col1": [1, 2, 3]})
-    sx.first_supported_datatype.return_value = "root"
+    sx.first_supported_datatype.return_value = "root-file"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray()
 
@@ -403,7 +403,7 @@ def test_sx_xaod_awkward_no_column_direct(async_mock):
     "Get the ak.Array directly with no dict access if we do not specify a column"
     sx = async_mock(spec=ServiceXDataset)
     sx.get_data_awkward_async.return_value = ak.Array({"col1": [1, 2, 3]})
-    sx.first_supported_datatype.return_value = "root"
+    sx.first_supported_datatype.return_value = "root-file"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray()
 
@@ -415,7 +415,7 @@ def test_sx_xaod_awkward_col_name_direct(async_mock):
     "Get the ak.Array directly with no dict access if we do not specify a column"
     sx = async_mock(spec=ServiceXDataset)
     sx.get_data_awkward_async.return_value = ak.Array({"col1": [1, 2, 3]})
-    sx.first_supported_datatype.return_value = "root"
+    sx.first_supported_datatype.return_value = "root-file"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsAwkwardArray("col1")
 
@@ -426,7 +426,7 @@ def test_sx_xaod_awkward_col_name_direct(async_mock):
 def test_sx_xaod_pandas(async_mock):
     "Test a request for awkward arrays from an xAOD backend"
     sx = async_mock(spec=ServiceXDataset)
-    sx.first_supported_datatype.return_value = "root"
+    sx.first_supported_datatype.return_value = "root-file"
     ds = ServiceXSourceXAOD(sx)
     q = ds.Select("lambda e: e.MET").AsPandasDF(["met"])
 


### PR DESCRIPTION
* Move from using `root` to `root-file` to reduce confusion
* Release some of the restrictions from the setup for dependent packages
* And tighten other restrictions to make sure we get the right version of servicex!